### PR TITLE
自动依赖更新 - 2025-10-07

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2163,14 +2163,14 @@
       }
     },
     "node_modules/@nuxt/cli": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.28.0.tgz",
-      "integrity": "sha512-WQ751WxWLBIeH3TDFt/LWQ2znyAKxpR5+gpv80oerwnVQs4GKajAfR6dIgExXZkjaPUHEFv2lVD9vM+frbprzw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.29.0.tgz",
+      "integrity": "sha512-qqToeBZPGCkMYJvHR/8j/qzmZwnLs2EVTV5eBalA5CfX8+NTdR1uqrhtHcZXO3vySoODFjzCCVIK5a6chtyeQQ==",
       "license": "MIT",
       "dependencies": {
-        "c12": "^3.2.0",
+        "c12": "^3.3.0",
         "citty": "^0.1.6",
-        "clipboardy": "^4.0.0",
+        "clipboardy": "^5.0.0",
         "confbox": "^0.2.2",
         "consola": "^3.4.2",
         "defu": "^6.1.4",
@@ -2179,20 +2179,21 @@
         "get-port-please": "^3.2.0",
         "giget": "^2.0.0",
         "h3": "^1.15.4",
-        "httpxy": "^0.1.7",
-        "jiti": "^2.5.1",
+        "jiti": "^2.6.1",
         "listhen": "^1.9.0",
-        "nypm": "^0.6.1",
+        "nypm": "^0.6.2",
         "ofetch": "^1.4.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^1.0.0",
-        "pkg-types": "^2.2.0",
+        "perfect-debounce": "^2.0.0",
+        "pkg-types": "^2.3.0",
         "scule": "^1.3.0",
         "semver": "^7.7.2",
+        "srvx": "^0.8.9",
         "std-env": "^3.9.0",
         "tinyexec": "^1.0.1",
         "ufo": "^1.6.1",
+        "undici": "^7.16.0",
         "youch": "^4.1.0-beta.11"
       },
       "bin": {
@@ -2204,12 +2205,6 @@
       "engines": {
         "node": "^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/@nuxt/cli/node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "license": "MIT"
     },
     "node_modules/@nuxt/devalue": {
       "version": "2.0.2",
@@ -2302,19 +2297,19 @@
       "license": "MIT"
     },
     "node_modules/@nuxt/kit": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.2.tgz",
-      "integrity": "sha512-+QiqO0WcIxsKLUqXdVn3m4rzTRm2fO9MZgd330utCAaagGmHsgiMJp67kE14boJEPutnikfz3qOmrzBnDIHUUg==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.19.3.tgz",
+      "integrity": "sha512-ze46EW5xW+UxDvinvPkYt2MzR355Az1lA3bpX8KDialgnCwr+IbkBij/udbUEC6ZFbidPkfK1eKl4ESN7gMY+w==",
       "license": "MIT",
       "dependencies": {
-        "c12": "^3.2.0",
+        "c12": "^3.3.0",
         "consola": "^3.4.2",
         "defu": "^6.1.4",
         "destr": "^2.0.5",
         "errx": "^0.1.0",
         "exsolve": "^1.0.7",
         "ignore": "^7.0.5",
-        "jiti": "^2.5.1",
+        "jiti": "^2.6.1",
         "klona": "^2.0.6",
         "knitwork": "^1.2.0",
         "mlly": "^1.8.0",
@@ -2328,7 +2323,7 @@
         "tinyglobby": "^0.2.15",
         "ufo": "^1.6.1",
         "unctx": "^2.4.1",
-        "unimport": "^5.2.0",
+        "unimport": "^5.4.1",
         "untyped": "^2.0.0"
       },
       "engines": {
@@ -2336,12 +2331,12 @@
       }
     },
     "node_modules/@nuxt/schema": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.19.2.tgz",
-      "integrity": "sha512-kMN2oIfrsMc8ACrRweYRG7Q44/KuHG5y7L+4szQhfOgN78OiYkxiM/nSsLH0K2bJq8Eavg+WGfgACj4Lsy+YqQ==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.19.3.tgz",
+      "integrity": "sha512-qgqy1trhTmy3fx7k+rW0xejtAxRZmjI45MxZnpsORypqwQYf+njtoY8tO1oTtsOtH9QaHfjCig7l8bGGkkL1rw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "^3.5.21",
+        "@vue/shared": "^3.5.22",
         "consola": "^3.4.2",
         "defu": "^6.1.4",
         "pathe": "^2.0.3",
@@ -2392,12 +2387,12 @@
       }
     },
     "node_modules/@nuxt/vite-builder": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.19.2.tgz",
-      "integrity": "sha512-SESdHAKWy63RKG3uqrBEJvTbfkmEsiggmDEqjEwhBP2fe0E6bGTmLpX/Eh4AuOLbZuZOmir984OHFiM/Q/MLhg==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.19.3.tgz",
+      "integrity": "sha512-pGCwOhNvWh4STIJdII0fkGKx80Heis2wK9X2lsTnu7oXQyTBnuqYxtP+l8sdqfX921v37ta++vskpRP1lYihCA==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "3.19.2",
+        "@nuxt/kit": "3.19.3",
         "@rollup/plugin-replace": "^6.0.2",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vitejs/plugin-vue-jsx": "^5.1.1",
@@ -2405,13 +2400,13 @@
         "consola": "^3.4.2",
         "cssnano": "^7.1.1",
         "defu": "^6.1.4",
-        "esbuild": "^0.25.9",
+        "esbuild": "^0.25.10",
         "escape-string-regexp": "^5.0.0",
         "exsolve": "^1.0.7",
         "externality": "^1.0.2",
         "get-port-please": "^3.2.0",
         "h3": "^1.15.4",
-        "jiti": "^2.5.1",
+        "jiti": "^2.6.1",
         "knitwork": "^1.2.0",
         "magic-string": "^0.30.19",
         "mlly": "^1.8.0",
@@ -2421,26 +2416,32 @@
         "perfect-debounce": "^2.0.0",
         "pkg-types": "^2.3.0",
         "postcss": "^8.5.6",
-        "rollup-plugin-visualizer": "^6.0.3",
+        "rollup-plugin-visualizer": "^6.0.4",
         "std-env": "^3.9.0",
         "ufo": "^1.6.1",
         "unenv": "^2.0.0-rc.21",
-        "vite": "^7.1.5",
+        "vite": "^7.1.9",
         "vite-node": "^3.2.4",
-        "vite-plugin-checker": "^0.10.3",
-        "vue-bundle-renderer": "^2.1.2"
+        "vite-plugin-checker": "^0.11.0",
+        "vue-bundle-renderer": "^2.2.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
+        "rolldown": "^1.0.0-beta.38",
         "vue": "^3.3.4"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        }
       }
     },
     "node_modules/@oxc-minify/binding-android-arm64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.87.0.tgz",
-      "integrity": "sha512-ZbJmAfXvNAamOSnXId3BiM3DiuzlD1isqKjtmRFb/hpvChHHA23FSPrFcO16w+ugZKg33sZ93FinFkKtlC4hww==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.94.0.tgz",
+      "integrity": "sha512-7VEBFFFAi4cYqlW/ziVs5XmNM/0IqAp7duBuTM/zus/EOc3Q2zhS9ApJo0zIwbRUZMlIm1RHe8Hths//xE7K1A==",
       "cpu": [
         "arm64"
       ],
@@ -2450,13 +2451,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-darwin-arm64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.87.0.tgz",
-      "integrity": "sha512-ewmNsTY8YbjWOI8+EOWKTVATOYvG4Qq4zQHH5VFBeqhQPVusY1ORD6Ei+BijVKrnlbpjibLlkTl8IWqXCGK89A==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.94.0.tgz",
+      "integrity": "sha512-T0k3pG/izIutpl8cQl9Xeb0TikBILGd3rglCgRhhG5G5xsk/AAAp/qsSdzBm/8yMXksfRWqE0teh7XDWKmzOXw==",
       "cpu": [
         "arm64"
       ],
@@ -2466,13 +2467,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-darwin-x64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.87.0.tgz",
-      "integrity": "sha512-qDH4w4EYttSC3Cs2VCh+CiMYKrcL2SNmnguBZXoUXe/RNk3csM+RhgcwdpX687xGvOhTFhH5PCIA84qh3ZpIbQ==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.94.0.tgz",
+      "integrity": "sha512-1gJeYcQf0Mmnu9Gxld2dLJGXTm9EzOQKRAjCVT2xGciKrNeekkJntDb+NdzxcSNPTjchkvbDwY6lCGZbcJx2lg==",
       "cpu": [
         "x64"
       ],
@@ -2482,13 +2483,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-freebsd-x64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.87.0.tgz",
-      "integrity": "sha512-5kxjHlSev2A09rDeITk+LMHxSrU3Iu8pUb0Zp4m+ul8FKlB9FrvFkAYwbctin6g47O98s3Win7Ewhy0w8JaiUA==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.94.0.tgz",
+      "integrity": "sha512-LvaxVkEVLgBNQO2RUYwbmRC0cLpq5WHPsM7B4xsojwqpJNsK5l2VnTAuExvPthC1gKWlsoQsVoT03Ex/SZ4FOw==",
       "cpu": [
         "x64"
       ],
@@ -2498,13 +2499,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.87.0.tgz",
-      "integrity": "sha512-NjbGXnNaAl5EgyonaDg2cPyH2pTf5a/+AP/5SRCJ0KetpXV22ZSUCvcy04Yt4QqjMcDs+WnJaGVxwx15Ofr6Gw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.94.0.tgz",
+      "integrity": "sha512-o/IEdJKl7Y78fIvIRPeA4ccgmOAzeMS8tsjpO7XlENWPzS3cA/6Iy4BqMqYyqUZewgt0a2ggw0zAioIwKPiDmw==",
       "cpu": [
         "arm"
       ],
@@ -2514,13 +2515,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.87.0.tgz",
-      "integrity": "sha512-llAjfCA0iV2LMMl+LTR3JhqAc2iQmj+DTKd0VWOrbNOuNczeE9D5kJFkqYplD73LrkuqxrX9oDeUjjeLdVBPXw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.94.0.tgz",
+      "integrity": "sha512-hFCeIV/eCASCW/F2t/DR4JUKUNxn2pr4hAIBEBYDaGPvdOVMlMh+eMbg401ZiaQLwM26Dj53b5XWALwit0mGAw==",
       "cpu": [
         "arm"
       ],
@@ -2530,13 +2531,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm64-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.87.0.tgz",
-      "integrity": "sha512-tf2Shom09AaSmu7U1hYYcEFF/cd+20HtmQ8eyGsRkqD5bqUj6lDu8TNSU9FWZ9tcZ83NzyFMwXZWHyeeIIbpxw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.94.0.tgz",
+      "integrity": "sha512-so/XF1XdJdpWVUkyz45F3iNJgzoXgeNBoYfmDTuLFIXE2U7vAtE8DHkA87LlbC6Ry7KIM4Ehw7hP4Z4h7M51fA==",
       "cpu": [
         "arm64"
       ],
@@ -2546,13 +2547,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-linux-arm64-musl": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.87.0.tgz",
-      "integrity": "sha512-pgWeYfSprtpnJVea9Q5eI6Eo80lDGlMw2JdcSMXmShtBjEhBl6bvDNHlV+6kNfh7iT65y/uC6FR8utFrRghu8A==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.94.0.tgz",
+      "integrity": "sha512-IMi2Sq3Z3xvA06Otit/D6Vo2BATZJcDHu6dHcaznBwnpO0z0+N9i3TKprIVizBHW77wq8QBLIbQaWQn4go1WwQ==",
       "cpu": [
         "arm64"
       ],
@@ -2562,13 +2563,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.87.0.tgz",
-      "integrity": "sha512-O1QPczlT+lqNZVeKOdFxxL+s1RIlnixaJYFLrcqDcRyn82MGKLz7sAenBTFRQoIfLnSxtMGL6dqHOefYkQx7Cg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.94.0.tgz",
+      "integrity": "sha512-1QWSK1CcmGwlJZBWCF+NpzpQ5c3WybtgVqeQX8FRIhlApBtvMsifZe4tz1FIoBoQeCKwCQzyvpIA71cpCpY/xg==",
       "cpu": [
         "riscv64"
       ],
@@ -2578,13 +2579,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-linux-s390x-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.87.0.tgz",
-      "integrity": "sha512-tcwt3ZUWOKfNLXN2edxFVHMlIuPvbuyMaKmRopgljSCfFcNHWhfTNlxlvmECRNhuQ91EcGwte6F1dwoeMCNd7A==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.94.0.tgz",
+      "integrity": "sha512-UfIuYWcs1tb/vwGwZPPVaO38OubKfi+MkySl2ZP/3Vk4InxtQ+BxxgNqiQbhyvx14GZtkFphH3I2FZaDUsvfYg==",
       "cpu": [
         "s390x"
       ],
@@ -2594,13 +2595,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-linux-x64-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.87.0.tgz",
-      "integrity": "sha512-Xf4AXF14KXUzSnfgTcFLFSM0TykJhFw14+xwNvlAb6WdqXAKlMrz9joIAezc8dkW1NNscCVTsqBUPJ4RhvCM1Q==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.94.0.tgz",
+      "integrity": "sha512-Iokd1dfneOcNHBJH8o5cMgDkII8R7dzOFSaMrZiSZkLr+woT3Ed7uLqTKwleNKq52z5+XwmgcvO00c6ywStCpA==",
       "cpu": [
         "x64"
       ],
@@ -2610,13 +2611,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-linux-x64-musl": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.87.0.tgz",
-      "integrity": "sha512-LIqvpx9UihEW4n9QbEljDnfUdAWqhr6dRqmzSFwVAeLZRUECluLCDdsdwemrC/aZkvnisA4w0LFcFr3HmeTLJg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.94.0.tgz",
+      "integrity": "sha512-W4hFq/e21o2cOKx9xltJuVo/xgXnn4SsUioo/86pk5vCmUXg++J0PMML/oOZTSbevlklg/Vxo8slRUSU4/0PzA==",
       "cpu": [
         "x64"
       ],
@@ -2626,29 +2627,29 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-wasm32-wasi": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.87.0.tgz",
-      "integrity": "sha512-h0xluvc+YryfH5G5dndjGHuA/D4Kp85EkPMxqoOjNudOKDCtdobEaC9horhCqnOOQ0lgn+PGFl3w8u4ToOuRrA==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.94.0.tgz",
+      "integrity": "sha512-0bOaEuh7QX8MfqyrRjNPOWhcsYl0IGoHX1nPtFIFGm0f/AJsJ+3wbyI9WvkAOXZmRgI9DMKGbDJdU6J59JxA7w==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.3"
+        "@napi-rs/wasm-runtime": "^1.0.6"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@oxc-minify/binding-win32-arm64-msvc": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.87.0.tgz",
-      "integrity": "sha512-fgxSx+TUc7e2rNtRAMnhHrjqh1e8p/JKmWxRZXtkILveMr/TOHGiDis7U3JJbwycmTZ+HSsJ/PNFQl+tKzmDxw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.94.0.tgz",
+      "integrity": "sha512-qXuSuUmLn7v79R0noaRlJES7m0BLfBWwPAmPjzu553eJObvKS15TfHH4uxr0h31Bmy4jqWX2r+oirz/Pg+hSEg==",
       "cpu": [
         "arm64"
       ],
@@ -2658,13 +2659,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-minify/binding-win32-x64-msvc": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.87.0.tgz",
-      "integrity": "sha512-K6TTrlitEJgD0FGIW2r0t3CIJNqBkzHT97h49gZLS24ey2UG1zKt27iSHkpXMJYDiG97ZD2yv3pSph1ctMlFXw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.94.0.tgz",
+      "integrity": "sha512-DtnN623PGZlNLRyyWtUQPEATeiGVnv9l8TMV9wCdd3AFNA9bmeFzmojcpwBFj/a5DOY5mds7cwC+Z+rjTPn+OQ==",
       "cpu": [
         "x64"
       ],
@@ -2674,13 +2675,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.87.0.tgz",
-      "integrity": "sha512-3APxTyYaAjpW5zifjzfsPgoIa4YHwA5GBjtgLRQpGVXCykXBIEbUTokoAs411ZuOwS3sdTVXBTGAdziXRd8rUg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.94.0.tgz",
+      "integrity": "sha512-Ficqj6MggRGFkemU4pVFTyth3jWVL/zpIWjGMTXaPU81l46ZDcYVFWp9ia6nfE5mm8UdVSI2trvmK+BpNUim7g==",
       "cpu": [
         "arm64"
       ],
@@ -2690,13 +2691,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.87.0.tgz",
-      "integrity": "sha512-99e8E76M+k3Gtwvs5EU3VTs2hQkJmvnrl/eu7HkBUc9jLFHA4nVjYSgukMuqahWe270udUYEPRfcWKmoE1Nukg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.94.0.tgz",
+      "integrity": "sha512-uYyeMH9vMfb0JAdm6ZwHTgcTv53030elQKMnUbux9K5rxOCWbHUyeVACEv86V+E/Ft6RtkvWDIqUY4sYZRmcuQ==",
       "cpu": [
         "arm64"
       ],
@@ -2706,13 +2707,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.87.0.tgz",
-      "integrity": "sha512-2rRo6Dz560/4ot5Q0KPUTEunEObkP8mDC9mMiH0RJk1FiOb9c+xpPbkYoUHNKuVMm8uIoiBCxIAbPtBhs9QaXQ==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.94.0.tgz",
+      "integrity": "sha512-Ek1fh8dw6b+/hzLo5jjPuxkshRxekjtTfhfWZ4RehMYiApT8Rj4k+7kcQ+zV1ZaF+1+yLgNqNja2RMRqx3MHzQ==",
       "cpu": [
         "x64"
       ],
@@ -2722,13 +2723,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.87.0.tgz",
-      "integrity": "sha512-uR+WZAvWkFQPVoeqXgQFr7iy+3hEI295qTbQ4ujmklgM5eTX3YgMFoIV00Stloxfd1irSDDSaK7ySnnzF6mRJg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.94.0.tgz",
+      "integrity": "sha512-81bE/8F252Ew179uVo9FU67dmRc+n8QSMhj6mmMxisdI3ao5MjCI5jDL19mH3UeQ9uRUBSPFILmHBDQYNZ9oKw==",
       "cpu": [
         "x64"
       ],
@@ -2738,13 +2739,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.87.0.tgz",
-      "integrity": "sha512-Emm1NpVGKbwzQOIZJI8ZuZu0z8FAd5xscqdS6qpDFpDdEMxk6ab7o3nM8V09RhNCORAzeUlk4TBHQ2Crzjd50A==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.94.0.tgz",
+      "integrity": "sha512-aGOU8IYXVYGN2aRrvcU5+UdM7BzIVlm4m0REQzjpblQKRdZfWFtDBRJez+fK/F10g0H1AU5DQVgbW5aeko49Jw==",
       "cpu": [
         "arm"
       ],
@@ -2754,13 +2755,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.87.0.tgz",
-      "integrity": "sha512-1PPCxRZSJXzQaqc8y+wH7EqPgSfQ/JU3pK6WTN/1SUe/8paNVSKKqk175a8BbRVxGUtPnwEG89pi+xfPTSE7GA==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.94.0.tgz",
+      "integrity": "sha512-69/ZuYSZ4dd7UWoEOyf+pXYPtvUZguDQqjhxMx8fI0J30sEEqs1d/DBLLnog/afHmaapPEIEr6rp9jF6bYcgNw==",
       "cpu": [
         "arm"
       ],
@@ -2770,13 +2771,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.87.0.tgz",
-      "integrity": "sha512-fcnnsfcyLamJOMVKq+BQ8dasb8gRnZtNpCUfZhaEFAdXQ7J2RmZreFzlygcn80iti0V7c5LejcjHbF4IdK3GAw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.94.0.tgz",
+      "integrity": "sha512-u55PGVVfZF/frpEcv/vowfuqsCd5VKz3wta8KZ3MBxboat7XxgRIMS8VQEBiJ3aYE80taACu5EfPN1y9DhiU0Q==",
       "cpu": [
         "arm64"
       ],
@@ -2786,13 +2787,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.87.0.tgz",
-      "integrity": "sha512-tBPkSPgRSSbmrje8CUovISi/Hj/tWjZJ3n/qnrjx2B+u86hWtwLsngtPDQa5d4seSyDaHSx6tNEUcH7+g5Ee0Q==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.94.0.tgz",
+      "integrity": "sha512-Qm2SEU7/f2b2Rg76Pj49BdMFF7Vv7+2qLPxaae4aH1515kzVv6nZW0bqCo4fPDDyiE4bryF7Jr+WKhllBxvXPw==",
       "cpu": [
         "arm64"
       ],
@@ -2802,13 +2803,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.87.0.tgz",
-      "integrity": "sha512-z4UKGM4wv2wEAQAlx2pBq6+pDJw5J/5oDEXqW6yBSLbWLjLDo4oagmRSE3+giOWteUa+0FVJ+ypq4iYxBkYSWg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.94.0.tgz",
+      "integrity": "sha512-bZO3QAt0lsZjk351mVM85obMivbXG+tDiah5XmmOaGO8k4vEYmoiKr2YHJoA2eNpKhPJF8dNyIS7U+XAvirr9g==",
       "cpu": [
         "riscv64"
       ],
@@ -2818,13 +2819,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.87.0.tgz",
-      "integrity": "sha512-6W1ENe/nZtr2TBnrEzmdGEraEAdZOiH3YoUNNeQWuqwLkmpoHTJJdclieToPe/l2IKJ4WL3FsSLSGHE8yt/OEg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.94.0.tgz",
+      "integrity": "sha512-IdbJ/rwsaEPQx11mQwGoClqhAmVaAF9+3VmDRYVmfsYsrhX1Ue1HvBdVHDvtHzJDuumC/X/codkVId9Ss+7fVg==",
       "cpu": [
         "s390x"
       ],
@@ -2834,13 +2835,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.87.0.tgz",
-      "integrity": "sha512-s3kB/Ii3X3IOZ27Iu7wx2zYkIcDO22Emu32SNC6kkUSy09dPBc1yaW14TnAkPMe/rvtuzR512JPWj3iGpl+Dng==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.94.0.tgz",
+      "integrity": "sha512-TbtpRdViF3aPCQBKuEo+TcucwW3KFa6bMHVakgaJu12RZrFpO4h1IWppBbuuBQ9X7SfvpgC1YgCDGve9q6fpEA==",
       "cpu": [
         "x64"
       ],
@@ -2850,13 +2851,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.87.0.tgz",
-      "integrity": "sha512-3+M9hfrZSDi4+Uy4Ll3rtOuVG3IHDQlj027jgtmAAHJK1eqp4CQfC7rrwE+LFUqUwX+KD2GwlxR+eHyyEf5Gbg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.94.0.tgz",
+      "integrity": "sha512-hlfoDmWvgSbexoJ9u3KwAJwpeu91FfJR6++fQjeYXD2InK4gZow9o3DRoTpN/kslZwzUNpiRURqxey/RvWh8JQ==",
       "cpu": [
         "x64"
       ],
@@ -2866,29 +2867,29 @@
         "linux"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.87.0.tgz",
-      "integrity": "sha512-2jgeEeOa4GbQQg2Et/gFTgs5wKS/+CxIg+CN2mMOJ4EqbmvUVeGiumO01oFOWTYnJy1oONwIocBzrnMuvOcItA==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.94.0.tgz",
+      "integrity": "sha512-VoCtQZIsRZN8mszbdizh+5MwzbgbMxsPgT2hOzzILQLNY2o2OXG3xSiFNFakVhbWc9qSTaZ/MRDsqR+IM3fLFw==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.3"
+        "@napi-rs/wasm-runtime": "^1.0.6"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.87.0.tgz",
-      "integrity": "sha512-KZp9poaBaVvuFM0TrsHCDOjPQK5eMDXblz21boMhKHGW5/bOlkMlg3CYn5j0f67FkK68NSdNKREMxmibBeXllQ==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.94.0.tgz",
+      "integrity": "sha512-3wsbMqV8V7WaLdiQ2oawdgKkCgMHXJ7VDuo6uIcXauU3wK6CG0QyDXRV9bPWzorGLRBUHndu/2VB1+9dgT9fvg==",
       "cpu": [
         "arm64"
       ],
@@ -2898,13 +2899,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.87.0.tgz",
-      "integrity": "sha512-86uisngtp/8XdcerIKxMyJTqgDSTJatkfpylpUH0d96W8Bb9E+bVvM2fIIhLWB0Eb03PeY2BdIT7DNIln9TnHg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.94.0.tgz",
+      "integrity": "sha512-UTQQ1576Nzhh4jr/YmvzqnuwTPOauB/TPzsnWzT+w8InHxL5JA1fmy01wB1F2BWT9AD6YV4BTB1ozRICYdAgjw==",
       "cpu": [
         "x64"
       ],
@@ -2914,22 +2915,22 @@
         "win32"
       ],
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.87.0.tgz",
-      "integrity": "sha512-ipZFWVGE9fADBVXXWJWY/cxpysc41Gt5upKDeb32F6WMgFyO7XETUMVq8UuREKCih+Km5E6p2VhEvf6Fuhey6g==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.94.0.tgz",
+      "integrity": "sha512-+UgQT/4o59cZfH6Cp7G0hwmqEQ0wE+AdIwhikdwnhWI9Dp8CgSY081+Q3O67/wq3VJu8mgUEB93J9EHHn70fOw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@oxc-transform/binding-android-arm64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.87.0.tgz",
-      "integrity": "sha512-B7W6J8T9cS054LUGLfYkYz8bz5+t+4yPftZ67Bn6MJ03okMLnbbEfm1bID1tqcP5tJwMurTILVy/dQfDYDcMgQ==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.94.0.tgz",
+      "integrity": "sha512-abxgEoomc5HNbDQaGhBWguR+W4cdrcEIwV8xIQ2qpUuhEUoHy6nQLfN/gREAZMdkyIaKwk12FckB9aNxVTte2w==",
       "cpu": [
         "arm64"
       ],
@@ -2939,13 +2940,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-darwin-arm64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.87.0.tgz",
-      "integrity": "sha512-HImW3xOPx7FHKqfC5WfE82onhRfnWQUiB7R+JgYrk+7NR404h3zANSPzu3V/W9lbDxlmHTcqoD2LKbNC5j0TQA==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.94.0.tgz",
+      "integrity": "sha512-HbnmwC1pZ9M/nXqA36TpwF7vcXk+PgLMxDvvza5C9CCivfi3MUfqCvFMvRI0snlVm2PK2GAwWJjBtng1fR8LJw==",
       "cpu": [
         "arm64"
       ],
@@ -2955,13 +2956,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-darwin-x64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.87.0.tgz",
-      "integrity": "sha512-MDbgugi6mvuPTfS78E2jyozm7493Kuqmpc5r406CsUdEsXlnsF+xvmKlrW9ZIkisO74dD+HWouSiDtNyPQHjlw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.94.0.tgz",
+      "integrity": "sha512-GADv5xcClQpYj5d6GLdPF6Qz/3OSn0d/LKhDklpW/5S42RQsGxI+83iXF1e61KITd4yp4VAvjEiuDM52zb4xYQ==",
       "cpu": [
         "x64"
       ],
@@ -2971,13 +2972,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-freebsd-x64": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.87.0.tgz",
-      "integrity": "sha512-N0M5D/4haJw7BMn2WZ3CWz0WkdLyoK1+3KxOyCv2CPedMCxx6eQay2AtJxSzj9tjVU1+ukbSb2fDO24JIJGsVA==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.94.0.tgz",
+      "integrity": "sha512-5H5V+H1CZoRQwbgAt/wLrN8oZwuYGP6xdXTuGUW2C2ON1DynMyxC4Padf8vjPcKbQph5GnLAuoaTafxokE2Z/Q==",
       "cpu": [
         "x64"
       ],
@@ -2987,13 +2988,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.87.0.tgz",
-      "integrity": "sha512-PubObCNOUOzm1S+P0yn7S+/6xRLbSPMqhgrb73L3p+J1Z20fv/FYVg0kFd36Yho24TSC/byOkebEZWAtxCasWw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.94.0.tgz",
+      "integrity": "sha512-BoWVkKUqgmUs4hDvGPgCSUkIeEMBVvHU/mO348Dhp7XT9ijdnSBmRzY6hFaqRSq768Hn6KblM0NM1QV7jEvKOw==",
       "cpu": [
         "arm"
       ],
@@ -3003,13 +3004,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.87.0.tgz",
-      "integrity": "sha512-Nk2d/FS7sMCmCl99vHojzigakjDPamkjOXs2i+H71o/NqytS0pk3M+tXat8M3IGpeLJIEszA5Mv+dcq731nlYA==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.94.0.tgz",
+      "integrity": "sha512-XUAyt2EtSDycljMKfgDVg/T5C3aF5dR1mfMJAZUCPQkfJjXZwA/C0DTTC/xPlPm68WA4uRtVNLqExTHJ3JOPwg==",
       "cpu": [
         "arm"
       ],
@@ -3019,13 +3020,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.87.0.tgz",
-      "integrity": "sha512-BxFkIcso2V1+FCDoU+KctxvJzSQVSnEZ5EEQ8O3Up9EoFVQRnZ8ktXvqYj2Oqvc4IYPskLPsKUgc9gdK8wGhUg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.94.0.tgz",
+      "integrity": "sha512-5Y7FI2FgawingojBEo3df4sI/Sq73UhVZy3DlT9o94Pgu8o+ujlKPD20kFmOJ1jQNEJ4ScKr5vh6pemHSZjUgA==",
       "cpu": [
         "arm64"
       ],
@@ -3035,13 +3036,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-linux-arm64-musl": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.87.0.tgz",
-      "integrity": "sha512-MZ1/TNaebhXK73j1UDfwyBFnAy0tT3n6otOkhlt1vlJwqboUS/D7E/XrCZmAuHIfVPxAXRPovkl7kfxLB43SKw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.94.0.tgz",
+      "integrity": "sha512-QiyHubpKo7upYPfwB+8bjaTczd60PJdL2zJrMKgL+CDlmP6HZlnWXZkeVTA3S6QXnbulRlrtERmqS2DePszG0g==",
       "cpu": [
         "arm64"
       ],
@@ -3051,13 +3052,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.87.0.tgz",
-      "integrity": "sha512-JCWE6n4Hicu0FVbvmLdH/dS8V6JykOUsbrbDYm6JwFlHr4eFTTlS2B+mh5KPOxcdeOlv/D/XRnvMJ6WGYs25EA==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.94.0.tgz",
+      "integrity": "sha512-vh3PZGmoUCbfkqVGuB7fweuqthYxzAAGqhiAJAn8x4V+R86W5esCtxbm+PTyVawBT/eoq1cU8HhNVqE0rQlChg==",
       "cpu": [
         "riscv64"
       ],
@@ -3067,13 +3068,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.87.0.tgz",
-      "integrity": "sha512-n2NTgM+3PqFagJV9UXRDNOmYesF+TO9SF9FeHqwVmW893ayef9KK+vfWAAhvOYHXYaKWT5XoHd87ODD7nruyhw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.94.0.tgz",
+      "integrity": "sha512-DT3m7cF612RdHBmYK3Ave6OVT1iSvlbKo8T+81n6ZcFXO+L8vDJHzwMwMOXfeOLQ15zr0WmSHqBOZ14tHKNidw==",
       "cpu": [
         "s390x"
       ],
@@ -3083,13 +3084,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-linux-x64-gnu": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.87.0.tgz",
-      "integrity": "sha512-ZOKW3wx0bW2O7jGdOzr8DyLZqX2C36sXvJdsHj3IueZZ//d/NjLZqEiUKz+q0JlERHtCVKShQ5PLaCx7NpuqNg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.94.0.tgz",
+      "integrity": "sha512-kK5dt8wfxUD3MGXnLHWxv57oYinIwoRFcjw2oJD5DCoGTeXCmrFk4D0eGPAlZKOm7uvWMs9yNI8rg1KY5nEs1w==",
       "cpu": [
         "x64"
       ],
@@ -3099,13 +3100,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-linux-x64-musl": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.87.0.tgz",
-      "integrity": "sha512-eIspx/JqkVMPK1CAYEOo2J8o49s4ZTf+32MSMUknIN2ZS1fvRmWS0D/xFFaLP/9UGhdrXRIPbn/iSYEA8JnV/g==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.94.0.tgz",
+      "integrity": "sha512-+zfNBO2qEPcSPTHVUxsiG3Hm0vxWzuL+DZX0wbbtjKwwhH2Jr1Eo26R+Dwc1SfbvoWen36NitKkd2arkpMW8KQ==",
       "cpu": [
         "x64"
       ],
@@ -3115,29 +3116,29 @@
         "linux"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-wasm32-wasi": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.87.0.tgz",
-      "integrity": "sha512-4uRjJQnt/+kmJUIC6Iwzn+MqqZhLP1zInPtDwgL37KI4VuUewUQWoL+sggMssMEgm7ZJwOPoZ6piuSWwMgOqgQ==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.94.0.tgz",
+      "integrity": "sha512-rn3c2wGT3ha6j0VLykYOkXU5YyQYIeGXRsDPP7xyiZHVTVssoM0X1BuheFlgxmC1POXMT+dAAcVOFG5MdW1bnQ==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.0.3"
+        "@napi-rs/wasm-runtime": "^1.0.6"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.87.0.tgz",
-      "integrity": "sha512-l/qSi4/N5W1yXKU9+1gWGo0tBoRpp4zvHYrpsbq3zbefPL4VYdA0gKF7O10/ZQVkYylzxiVh2zpYO34/FbZdIg==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.94.0.tgz",
+      "integrity": "sha512-An/Dd+I8dH0b+VLEdfTrZP53S4Fha3w/aD71d1uZB14aU02hBt3ZwU8IE3RGZIJPxub9OZmCmJN66uTqkT6oXg==",
       "cpu": [
         "arm64"
       ],
@@ -3147,13 +3148,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-transform/binding-win32-x64-msvc": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.87.0.tgz",
-      "integrity": "sha512-jG/MhMjfSdyj5KyhnwNWr4mnAlAsz+gNUYpjQ+UXWsfsoB3f8HqbsTkG02RBtNa/IuVQYvYYVf1eIimNN3gBEQ==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.94.0.tgz",
+      "integrity": "sha512-HEE/8x6H67jPlkCDDB3xl74eR86zY6nLAql6onmidF5JPNXt9v2XGB6xEwr4brUIaMLPkl90plbdCy9jWhEjdQ==",
       "cpu": [
         "x64"
       ],
@@ -3163,7 +3164,7 @@
         "win32"
       ],
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -4097,6 +4098,12 @@
         "win32"
       ]
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.1.0.tgz",
@@ -4777,9 +4784,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
-      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
+      "integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -4826,12 +4833,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
-      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
+      "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.13.0"
+        "undici-types": "~7.14.0"
       }
     },
     "node_modules/@types/nodemailer": {
@@ -5014,9 +5021,9 @@
       }
     },
     "node_modules/@vitejs/plugin-vue-jsx/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.41",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.41.tgz",
-      "integrity": "sha512-ycMEPrS3StOIeb87BT3/+bu+blEtyvwQ4zmo2IcJQy0Rd1DAAhKksA0iUZ3MYSpJtjlPhg0Eo6mvVS6ggPhRbw==",
+      "version": "1.0.0-beta.42",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.42.tgz",
+      "integrity": "sha512-N7pQzk9CyE7q0bBN/q0J8s6Db279r5kUZc6d7/wWRe9/zXqC52HQovVyu6iXPIDY4BEzzgbVLhVFXrOuGJ22ZQ==",
       "license": "MIT"
     },
     "node_modules/@volar/language-core": {
@@ -5227,9 +5234,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.0.tgz",
-      "integrity": "sha512-a7ns+X9vTbdmk7QLrvnZs8s4E1wwtxG/sELzr6F2j4pU+r/OoAv6jJGSz+5tVTU6e4+3rjepGhSP8jDmBBcb3w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.1.1.tgz",
+      "integrity": "sha512-qjMY3Q+hUCjdH+jLrQapqgpsJ0rd/2mAY02lZoHG3VFJZZZKLjAlV+Oo9QmWIT4jh8+Rx8RUGUi++d7T9Wb6Mw==",
       "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.23",
@@ -5516,32 +5523,32 @@
       "license": "MIT"
     },
     "node_modules/ast-kit": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.1.2.tgz",
-      "integrity": "sha512-cl76xfBQM6pztbrFWRnxbrDm9EOqDr1BF6+qQnnDZG2Co2LjyUktkN9GTJfBAfdae+DbT2nJf2nCGAdDDN7W2g==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.1.3.tgz",
+      "integrity": "sha512-TH+b3Lv6pUjy/Nu0m6A2JULtdzLpmqF9x1Dhj00ZoEiML8qvVA9j1flkzTKNYgdEhWrjDwtWNpyyCUbfQe514g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
+        "@babel/parser": "^7.28.4",
         "pathe": "^2.0.3"
       },
       "engines": {
-        "node": ">=20.18.0"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/ast-walker-scope": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.2.tgz",
-      "integrity": "sha512-3pYeLyDZ6nJew9QeBhS4Nly02269Dkdk32+zdbbKmL6n4ZuaGorwwA+xx12xgOciA8BF1w9x+dlH7oUkFTW91w==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.3.tgz",
+      "integrity": "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "ast-kit": "^2.1.2"
+        "@babel/parser": "^7.28.4",
+        "ast-kit": "^2.1.3"
       },
       "engines": {
-        "node": ">=20.18.0"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
@@ -6007,15 +6014,131 @@
       }
     },
     "node_modules/clipboardy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
-      "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-5.0.0.tgz",
+      "integrity": "sha512-MQfKHaD09eP80Pev4qBxZLbxJK/ONnqfSYAPlCmPh+7BDboYtO/3BmB6HGzxDIT0SlTRc2tzS8lQqfcdLtZ0Kg==",
       "license": "MIT",
       "dependencies": {
-        "execa": "^8.0.1",
+        "execa": "^9.6.0",
+        "is-wayland": "^0.1.0",
         "is-wsl": "^3.1.0",
         "is64bit": "^2.0.0"
       },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/execa": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
+      "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/clipboardy/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/clipboardy/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -7043,9 +7166,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.230",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.230.tgz",
-      "integrity": "sha512-A6A6Fd3+gMdaed9wX83CvHYJb4UuapPD5X5SLq72VZJzxHSY0/LUweGXRWmQlh2ln7KV7iw7jnwXK7dlPoOnHQ==",
+      "version": "1.5.232",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.232.tgz",
+      "integrity": "sha512-ENirSe7wf8WzyPCibqKUG1Cg43cPaxH4wRR7AJsX7MCABCHBIOFqvaYODSLKUuZdraxUTHRE/0A2Aq8BYKEHOg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -7423,6 +7546,21 @@
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "license": "MIT"
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -8020,9 +8158,9 @@
       "license": "MIT"
     },
     "node_modules/ioredis": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.0.tgz",
-      "integrity": "sha512-AUXbKn9gvo9hHKvk6LbZJQSKn/qIfkWXrnsyL9Yrf+oeXmla9Nmf6XEumOddyhM8neynpK5oAV6r9r99KBuwzA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.1.tgz",
+      "integrity": "sha512-Qho8TgIamqEPdgiMadJwzRMW3TudIg6vpg4YONokGDudy4eqRIJtDbVX72pfLBcWxvbn3qm/40TyGUObdW4tLQ==",
       "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "1.4.0",
@@ -8173,6 +8311,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -8198,6 +8348,30 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wayland": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-wayland/-/is-wayland-0.1.0.tgz",
+      "integrity": "sha512-QkbMsWkIfkrzOPxenwye0h56iAXirZYHG9eHVPb22fO9y+wPbaX/CHacOWBa/I++4ohTcByimhM1/nyCsH8KNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8492,6 +8666,23 @@
         "listhen": "bin/listhen.mjs"
       }
     },
+    "node_modules/listhen/node_modules/clipboardy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
+      "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^8.0.1",
+        "is-wsl": "^3.1.0",
+        "is64bit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/listhen/node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -8621,15 +8812,15 @@
       }
     },
     "node_modules/magic-string-ast": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.2.tgz",
-      "integrity": "sha512-8ngQgLhcT0t3YBdn9CGkZqCYlvwW9pm7aWJwd7AxseVWf1RU8ZHCQvG1mt3N5vvUme+pXTcHB8G/7fE666U8Vw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.3.tgz",
+      "integrity": "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==",
       "license": "MIT",
       "dependencies": {
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.19"
       },
       "engines": {
-        "node": ">=20.18.0"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
@@ -9013,9 +9204,9 @@
       }
     },
     "node_modules/nitropack/node_modules/unplugin-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.0.tgz",
-      "integrity": "sha512-JLoggz+PvLVMJo+jZt97hdIIIZ2yTzGgft9e9q8iMrC4ewufl62ekeW7mixBghonn2gVb/ICjyvlmOCUBnJLQg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
+      "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3",
@@ -9177,21 +9368,21 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.19.2.tgz",
-      "integrity": "sha512-z4ouGRMOWqZ1xaZ+HdRBRVlZcKSoDBpRxQ30GJ2dllraZMC/gNpTGuY32H3xP5b4R29b8uYcK+B8LFQoRHpO8A==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.19.3.tgz",
+      "integrity": "sha512-J5vfkt69gamnl81iDgeSi1tZ0ADEesKfZizPfKxY10dMdjuelAo9WYItFmFGWZ9j1+uXtFJ+PLzqGmXfPLBsuw==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/cli": "^3.28.0",
+        "@nuxt/cli": "^3.29.0",
         "@nuxt/devalue": "^2.0.2",
-        "@nuxt/devtools": "^2.6.3",
-        "@nuxt/kit": "3.19.2",
-        "@nuxt/schema": "3.19.2",
+        "@nuxt/devtools": "^2.6.5",
+        "@nuxt/kit": "3.19.3",
+        "@nuxt/schema": "3.19.3",
         "@nuxt/telemetry": "^2.6.6",
-        "@nuxt/vite-builder": "3.19.2",
+        "@nuxt/vite-builder": "3.19.3",
         "@unhead/vue": "^2.0.14",
-        "@vue/shared": "^3.5.21",
-        "c12": "^3.2.0",
+        "@vue/shared": "^3.5.22",
+        "c12": "^3.3.0",
         "chokidar": "^4.0.3",
         "compatx": "^0.2.0",
         "consola": "^3.4.2",
@@ -9200,7 +9391,7 @@
         "destr": "^2.0.5",
         "devalue": "^5.3.2",
         "errx": "^0.1.0",
-        "esbuild": "^0.25.9",
+        "esbuild": "^0.25.10",
         "escape-string-regexp": "^5.0.0",
         "estree-walker": "^3.0.3",
         "exsolve": "^1.0.7",
@@ -9208,21 +9399,21 @@
         "hookable": "^5.5.3",
         "ignore": "^7.0.5",
         "impound": "^1.0.0",
-        "jiti": "^2.5.1",
+        "jiti": "^2.6.1",
         "klona": "^2.0.6",
         "knitwork": "^1.2.0",
         "magic-string": "^0.30.19",
         "mlly": "^1.8.0",
         "mocked-exports": "^0.1.1",
         "nanotar": "^0.2.0",
-        "nitropack": "^2.12.5",
-        "nypm": "^0.6.1",
+        "nitropack": "^2.12.6",
+        "nypm": "^0.6.2",
         "ofetch": "^1.4.1",
         "ohash": "^2.0.11",
-        "on-change": "^5.0.1",
-        "oxc-minify": "^0.87.0",
-        "oxc-parser": "^0.87.0",
-        "oxc-transform": "^0.87.0",
+        "on-change": "^6.0.0",
+        "oxc-minify": "^0.94.0",
+        "oxc-parser": "^0.94.0",
+        "oxc-transform": "^0.94.0",
         "oxc-walker": "^0.5.2",
         "pathe": "^2.0.3",
         "perfect-debounce": "^2.0.0",
@@ -9236,13 +9427,13 @@
         "ultrahtml": "^1.6.0",
         "uncrypto": "^0.1.3",
         "unctx": "^2.4.1",
-        "unimport": "^5.2.0",
+        "unimport": "^5.4.1",
         "unplugin": "^2.3.10",
         "unplugin-vue-router": "^0.15.0",
         "unstorage": "^1.17.1",
         "untyped": "^2.0.0",
-        "vue": "^3.5.21",
-        "vue-bundle-renderer": "^2.1.2",
+        "vue": "^3.5.22",
+        "vue-bundle-renderer": "^2.2.0",
         "vue-devtools-stub": "^0.1.0",
         "vue-router": "^4.5.1"
       },
@@ -9312,12 +9503,12 @@
       "license": "MIT"
     },
     "node_modules/on-change": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/on-change/-/on-change-5.0.1.tgz",
-      "integrity": "sha512-n7THCP7RkyReRSLkJb8kUWoNsxUIBxTkIp3JKno+sEz6o/9AJ3w3P9fzQkITEkMwyTKJjZciF3v/pVoouxZZMg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/on-change/-/on-change-6.0.0.tgz",
+      "integrity": "sha512-J7kocOS+ZNyjmW6tUUTtA7jLt8GjQlrOdz9z3yLNTvdsswO+b5lYSdMVzDczWnooyFAkkQiKyap5g/Zba+cFRA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/on-change?sponsor=1"
@@ -9404,93 +9595,93 @@
       }
     },
     "node_modules/oxc-minify": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.87.0.tgz",
-      "integrity": "sha512-+UHWp6+0mdq0S2rEsZx9mqgL6JnG9ogO+CU17XccVrPUFtISFcZzk/biTn1JdBYFQ3kztof19pv8blMtgStQ2g==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.94.0.tgz",
+      "integrity": "sha512-7+9iyxwpzfjuiEnSqNJYzTsC1Oud742PPkr/4S1bGY930U4tApdLEK8zmgbT57c1/56cfNOndqZaeQZiAfnJ5A==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-minify/binding-android-arm64": "0.87.0",
-        "@oxc-minify/binding-darwin-arm64": "0.87.0",
-        "@oxc-minify/binding-darwin-x64": "0.87.0",
-        "@oxc-minify/binding-freebsd-x64": "0.87.0",
-        "@oxc-minify/binding-linux-arm-gnueabihf": "0.87.0",
-        "@oxc-minify/binding-linux-arm-musleabihf": "0.87.0",
-        "@oxc-minify/binding-linux-arm64-gnu": "0.87.0",
-        "@oxc-minify/binding-linux-arm64-musl": "0.87.0",
-        "@oxc-minify/binding-linux-riscv64-gnu": "0.87.0",
-        "@oxc-minify/binding-linux-s390x-gnu": "0.87.0",
-        "@oxc-minify/binding-linux-x64-gnu": "0.87.0",
-        "@oxc-minify/binding-linux-x64-musl": "0.87.0",
-        "@oxc-minify/binding-wasm32-wasi": "0.87.0",
-        "@oxc-minify/binding-win32-arm64-msvc": "0.87.0",
-        "@oxc-minify/binding-win32-x64-msvc": "0.87.0"
+        "@oxc-minify/binding-android-arm64": "0.94.0",
+        "@oxc-minify/binding-darwin-arm64": "0.94.0",
+        "@oxc-minify/binding-darwin-x64": "0.94.0",
+        "@oxc-minify/binding-freebsd-x64": "0.94.0",
+        "@oxc-minify/binding-linux-arm-gnueabihf": "0.94.0",
+        "@oxc-minify/binding-linux-arm-musleabihf": "0.94.0",
+        "@oxc-minify/binding-linux-arm64-gnu": "0.94.0",
+        "@oxc-minify/binding-linux-arm64-musl": "0.94.0",
+        "@oxc-minify/binding-linux-riscv64-gnu": "0.94.0",
+        "@oxc-minify/binding-linux-s390x-gnu": "0.94.0",
+        "@oxc-minify/binding-linux-x64-gnu": "0.94.0",
+        "@oxc-minify/binding-linux-x64-musl": "0.94.0",
+        "@oxc-minify/binding-wasm32-wasi": "0.94.0",
+        "@oxc-minify/binding-win32-arm64-msvc": "0.94.0",
+        "@oxc-minify/binding-win32-x64-msvc": "0.94.0"
       }
     },
     "node_modules/oxc-parser": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.87.0.tgz",
-      "integrity": "sha512-uc47XrtHwkBoES4HFgwgfH9sqwAtJXgAIBq4fFBMZ4hWmgVZoExyn+L4g4VuaecVKXkz1bvlaHcfwHAJPQb5Gw==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.94.0.tgz",
+      "integrity": "sha512-refms9HQoAlTYIazONYkuX5A3rFGPddbD6Otyc+A0/pj1WTttR8TsZRlMzQxCfhexxfrbinqd7ebkEoYNuCmLQ==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.87.0"
+        "@oxc-project/types": "^0.94.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm64": "0.87.0",
-        "@oxc-parser/binding-darwin-arm64": "0.87.0",
-        "@oxc-parser/binding-darwin-x64": "0.87.0",
-        "@oxc-parser/binding-freebsd-x64": "0.87.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.87.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.87.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.87.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.87.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.87.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.87.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.87.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.87.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.87.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.87.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.87.0"
+        "@oxc-parser/binding-android-arm64": "0.94.0",
+        "@oxc-parser/binding-darwin-arm64": "0.94.0",
+        "@oxc-parser/binding-darwin-x64": "0.94.0",
+        "@oxc-parser/binding-freebsd-x64": "0.94.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.94.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.94.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.94.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.94.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.94.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.94.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.94.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.94.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.94.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.94.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.94.0"
       }
     },
     "node_modules/oxc-transform": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.87.0.tgz",
-      "integrity": "sha512-dt6INKWY2DKbSc8yR9VQoqBsCjPQ3z/SKv882UqlwFve+K38xtpi2avDlvNd35SpHUwDLDFoV3hMX0U3qOSaaQ==",
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.94.0.tgz",
+      "integrity": "sha512-nHFFyPVWNNe7WLsAiQ6iwfsuTW/1esT+BJg+9rlvcSa0mfcZTpNo3TlBfj9IerLdDmYHJnSYsx8jjFZhoGfZ1w==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-transform/binding-android-arm64": "0.87.0",
-        "@oxc-transform/binding-darwin-arm64": "0.87.0",
-        "@oxc-transform/binding-darwin-x64": "0.87.0",
-        "@oxc-transform/binding-freebsd-x64": "0.87.0",
-        "@oxc-transform/binding-linux-arm-gnueabihf": "0.87.0",
-        "@oxc-transform/binding-linux-arm-musleabihf": "0.87.0",
-        "@oxc-transform/binding-linux-arm64-gnu": "0.87.0",
-        "@oxc-transform/binding-linux-arm64-musl": "0.87.0",
-        "@oxc-transform/binding-linux-riscv64-gnu": "0.87.0",
-        "@oxc-transform/binding-linux-s390x-gnu": "0.87.0",
-        "@oxc-transform/binding-linux-x64-gnu": "0.87.0",
-        "@oxc-transform/binding-linux-x64-musl": "0.87.0",
-        "@oxc-transform/binding-wasm32-wasi": "0.87.0",
-        "@oxc-transform/binding-win32-arm64-msvc": "0.87.0",
-        "@oxc-transform/binding-win32-x64-msvc": "0.87.0"
+        "@oxc-transform/binding-android-arm64": "0.94.0",
+        "@oxc-transform/binding-darwin-arm64": "0.94.0",
+        "@oxc-transform/binding-darwin-x64": "0.94.0",
+        "@oxc-transform/binding-freebsd-x64": "0.94.0",
+        "@oxc-transform/binding-linux-arm-gnueabihf": "0.94.0",
+        "@oxc-transform/binding-linux-arm-musleabihf": "0.94.0",
+        "@oxc-transform/binding-linux-arm64-gnu": "0.94.0",
+        "@oxc-transform/binding-linux-arm64-musl": "0.94.0",
+        "@oxc-transform/binding-linux-riscv64-gnu": "0.94.0",
+        "@oxc-transform/binding-linux-s390x-gnu": "0.94.0",
+        "@oxc-transform/binding-linux-x64-gnu": "0.94.0",
+        "@oxc-transform/binding-linux-x64-musl": "0.94.0",
+        "@oxc-transform/binding-wasm32-wasi": "0.94.0",
+        "@oxc-transform/binding-win32-arm64-msvc": "0.94.0",
+        "@oxc-transform/binding-win32-x64-msvc": "0.94.0"
       }
     },
     "node_modules/oxc-walker": {
@@ -9522,6 +9713,18 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parse-path": {
       "version": "7.1.0",
@@ -10228,6 +10431,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -10898,6 +11116,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/srvx": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.8.9.tgz",
+      "integrity": "sha512-wYc3VLZHRzwYrWJhkEqkhLb31TI0SOkfYZDkUhXdp3NoCnNS0FqajiQszZZjfow/VYEuc6Q5sZh9nM6kPy2NBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^2.0.0"
+      },
+      "bin": {
+        "srvx": "bin/srvx.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0"
+      }
+    },
     "node_modules/ssf": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
@@ -11460,10 +11693,19 @@
         "unplugin": "^2.1.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
-      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -11529,9 +11771,9 @@
       }
     },
     "node_modules/unimport/node_modules/unplugin-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.0.tgz",
-      "integrity": "sha512-JLoggz+PvLVMJo+jZt97hdIIIZ2yTzGgft9e9q8iMrC4ewufl62ekeW7mixBghonn2gVb/ICjyvlmOCUBnJLQg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
+      "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3",
@@ -11936,9 +12178,9 @@
       }
     },
     "node_modules/vite-plugin-checker": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.10.3.tgz",
-      "integrity": "sha512-f4sekUcDPF+T+GdbbE8idb1i2YplBAoH+SfRS0e/WRBWb2rYb1Jf5Pimll0Rj+3JgIYWwG2K5LtBPCXxoibkLg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.11.0.tgz",
+      "integrity": "sha512-iUdO9Pl9UIBRPAragwi3as/BXXTtRu4G12L3CMrjx+WVTd9g/MsqNakreib9M/2YRVkhZYiTEwdH2j4Dm0w7lw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -11946,22 +12188,22 @@
         "npm-run-path": "^6.0.0",
         "picocolors": "^1.1.1",
         "picomatch": "^4.0.3",
-        "strip-ansi": "^7.1.0",
         "tiny-invariant": "^1.3.3",
         "tinyglobby": "^0.2.14",
         "vscode-uri": "^3.1.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16.11"
       },
       "peerDependencies": {
         "@biomejs/biome": ">=1.7",
         "eslint": ">=7",
         "meow": "^13.2.0",
         "optionator": "^0.9.4",
+        "oxlint": ">=1",
         "stylelint": ">=16",
         "typescript": "*",
-        "vite": ">=2.0.0",
+        "vite": ">=5.4.20",
         "vls": "*",
         "vti": "*",
         "vue-tsc": "~2.2.10 || ^3.0.0"
@@ -11977,6 +12219,9 @@
           "optional": true
         },
         "optionator": {
+          "optional": true
+        },
+        "oxlint": {
           "optional": true
         },
         "stylelint": {
@@ -12086,9 +12331,9 @@
       }
     },
     "node_modules/vite-plugin-inspect/node_modules/unplugin-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.0.tgz",
-      "integrity": "sha512-JLoggz+PvLVMJo+jZt97hdIIIZ2yTzGgft9e9q8iMrC4ewufl62ekeW7mixBghonn2gVb/ICjyvlmOCUBnJLQg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
+      "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3",
@@ -12491,6 +12736,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/youch": {
       "version": "4.1.0-beta.11",
       "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.11.tgz",
@@ -12545,9 +12802,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
## 自动依赖更新

- 触发时间: 2025-10-07
- 工作流: dependency-update.yml
- Node.js 版本: 18

<details>
<summary>📋 详细更新信息（点击展开）</summary>

#### 更新的文件
- package-lock.json 已更新



#### 安全审计结果
```
正在运行安全审计...

# npm audit report

esbuild  <=0.24.2
Severity: moderate
esbuild enables any website to send any requests to the development server and read the response - https://github.com/advisories/GHSA-67mh-4wv8-2f99
fix available via `npm audit fix --force`
Will install drizzle-kit@0.18.1, which is a breaking change
node_modules/@esbuild-kit/core-utils/node_modules/esbuild
  @esbuild-kit/core-utils  *
  Depends on vulnerable versions of esbuild
  node_modules/@esbuild-kit/core-utils
    @esbuild-kit/esm-loader  *
    Depends on vulnerable versions of @esbuild-kit/core-utils
    node_modules/@esbuild-kit/esm-loader
      drizzle-kit  0.17.5-6b7793f - 0.17.5-e5944eb || 0.18.1-065de38 - 0.18.1-f3800bf || >=0.19.0-07024c4
      Depends on vulnerable versions of @esbuild-kit/esm-loader
      node_modules/drizzle-kit

xlsx  *
Severity: high
Prototype Pollution in sheetJS - https://github.com/advisories/GHSA-4r6h-8v6p-xvw6
SheetJS Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-5pgg-2g8v-p4x9
No fix available
node_modules/xlsx

5 vulnerabilities (4 moderate, 1 high)

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

--- 审计摘要 ---
总计发现: 5 vulnerabilities
漏洞详情:
esbuild  <=0.24.2
Severity: moderate
esbuild enables any website to send any requests to the development server and read the response - https://github.com/advisories/GHSA-67mh-4wv8-2f99
fix available via `npm audit fix --force`
--
xlsx  *
Severity: high
Prototype Pollution in sheetJS - https://github.com/advisories/GHSA-4r6h-8v6p-xvw6
SheetJS Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-5pgg-2g8v-p4x9
```

</details>