### PR TITLE
自动依赖更新 - 2025-10-10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -166,24 +166,24 @@
       }
     },
     "node_modules/@aws-sdk/client-ses": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.901.0.tgz",
-      "integrity": "sha512-CJfIsqloxgFvTb3arx/ZGVfxWo6zA8VzNQoMowd1G8ab6PjsqFSWufRGbQcvfwuKoUhHvtPAZw1zrqp7LJwAww==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.907.0.tgz",
+      "integrity": "sha512-y0J1F4nKwqu2b73t/mn/X1NhYZeOte87SZeExW7pzfbouMKUyhJFPVgggDXT1E3kUq7S5Y0GVz1ogvm+KngWaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.901.0",
-        "@aws-sdk/credential-provider-node": "3.901.0",
+        "@aws-sdk/core": "3.907.0",
+        "@aws-sdk/credential-provider-node": "3.907.0",
         "@aws-sdk/middleware-host-header": "3.901.0",
         "@aws-sdk/middleware-logger": "3.901.0",
         "@aws-sdk/middleware-recursion-detection": "3.901.0",
-        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.907.0",
         "@aws-sdk/region-config-resolver": "3.901.0",
         "@aws-sdk/types": "3.901.0",
         "@aws-sdk/util-endpoints": "3.901.0",
-        "@aws-sdk/util-user-agent-browser": "3.901.0",
-        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.907.0",
+        "@aws-sdk/util-user-agent-node": "3.907.0",
         "@smithy/config-resolver": "^4.3.0",
         "@smithy/core": "^3.14.0",
         "@smithy/fetch-http-handler": "^5.3.0",
@@ -217,23 +217,23 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.901.0.tgz",
-      "integrity": "sha512-sGyDjjkJ7ppaE+bAKL/Q5IvVCxtoyBIzN+7+hWTS/mUxWJ9EOq9238IqmVIIK6sYNIzEf9yhobfMARasPYVTNg==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.907.0.tgz",
+      "integrity": "sha512-ANuu0duNTcQHv0g5YrEuWImT8o9t6li3A+MtAaKxIbTA3eFQnl6xHDxyrbsrU19FtKPg3CWhvfY04j6DaDvR8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/core": "3.907.0",
         "@aws-sdk/middleware-host-header": "3.901.0",
         "@aws-sdk/middleware-logger": "3.901.0",
         "@aws-sdk/middleware-recursion-detection": "3.901.0",
-        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.907.0",
         "@aws-sdk/region-config-resolver": "3.901.0",
         "@aws-sdk/types": "3.901.0",
         "@aws-sdk/util-endpoints": "3.901.0",
-        "@aws-sdk/util-user-agent-browser": "3.901.0",
-        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.907.0",
+        "@aws-sdk/util-user-agent-node": "3.907.0",
         "@smithy/config-resolver": "^4.3.0",
         "@smithy/core": "^3.14.0",
         "@smithy/fetch-http-handler": "^5.3.0",
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.901.0.tgz",
-      "integrity": "sha512-brKAc3y64tdhyuEf+OPIUln86bRTqkLgb9xkd6kUdIeA5+qmp/N6amItQz+RN4k4O3kqkCPYnAd3LonTKluobw==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.907.0.tgz",
+      "integrity": "sha512-vuIHL8qUcA5oNi7IWSZauCMaXstWTcSsnK1iHcvg92ddGDo1LMd2kQNo0G9UANa8vOfc908+8xKO40gfL8+M7w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.901.0",
@@ -290,12 +290,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.901.0.tgz",
-      "integrity": "sha512-5hAdVl3tBuARh3zX5MLJ1P/d+Kr5kXtDU3xm1pxUEF4xt2XkEEpwiX5fbkNkz2rbh3BCt2gOHsAbh6b3M7n+DA==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.907.0.tgz",
+      "integrity": "sha512-orqT6djon57y09Ci5q0kezisrEvr78Z+7WvZbq0ZC0Ncul4RgJfCmhcgmzNPaWA18NEI0wGytaxYh3YFE7kIBQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/core": "3.907.0",
         "@aws-sdk/types": "3.901.0",
         "@smithy/property-provider": "^4.2.0",
         "@smithy/types": "^4.6.0",
@@ -306,12 +306,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.901.0.tgz",
-      "integrity": "sha512-Ggr7+0M6QZEsrqRkK7iyJLf4LkIAacAxHz9c4dm9hnDdU7vqrlJm6g73IxMJXWN1bIV7IxfpzB11DsRrB/oNjQ==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.907.0.tgz",
+      "integrity": "sha512-CKG/0hT4o8K2aQKOe+xwGP3keSNOyryhZNmKuHPuMRVlsJfO6wNxlu37HcUPzihJ+S2pOmTVGUbeVMCxJVUJmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/core": "3.907.0",
         "@aws-sdk/types": "3.901.0",
         "@smithy/fetch-http-handler": "^5.3.0",
         "@smithy/node-http-handler": "^4.3.0",
@@ -327,18 +327,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.901.0.tgz",
-      "integrity": "sha512-zxadcDS0hNJgv8n4hFYJNOXyfjaNE1vvqIiF/JzZSQpSSYXzCd+WxXef5bQh+W3giDtRUmkvP5JLbamEFjZKyw==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.907.0.tgz",
+      "integrity": "sha512-Clz1YdXrgQ5WIlcRE7odHbgM/INBxy49EA3csDITafHaDPtPRL39zkQtB5+Lwrrt/Gg0xBlyTbvP5Snan+0lqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.901.0",
-        "@aws-sdk/credential-provider-env": "3.901.0",
-        "@aws-sdk/credential-provider-http": "3.901.0",
-        "@aws-sdk/credential-provider-process": "3.901.0",
-        "@aws-sdk/credential-provider-sso": "3.901.0",
-        "@aws-sdk/credential-provider-web-identity": "3.901.0",
-        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/core": "3.907.0",
+        "@aws-sdk/credential-provider-env": "3.907.0",
+        "@aws-sdk/credential-provider-http": "3.907.0",
+        "@aws-sdk/credential-provider-process": "3.907.0",
+        "@aws-sdk/credential-provider-sso": "3.907.0",
+        "@aws-sdk/credential-provider-web-identity": "3.907.0",
+        "@aws-sdk/nested-clients": "3.907.0",
         "@aws-sdk/types": "3.901.0",
         "@smithy/credential-provider-imds": "^4.2.0",
         "@smithy/property-provider": "^4.2.0",
@@ -351,17 +351,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.901.0.tgz",
-      "integrity": "sha512-dPuFzMF7L1s/lQyT3wDxqLe82PyTH+5o1jdfseTEln64LJMl0ZMWaKX/C1UFNDxaTd35Cgt1bDbjjAWHMiKSFQ==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.907.0.tgz",
+      "integrity": "sha512-w6Hhc4rV/CFaBliIh9Ph/T59xdGcTF6WmPGzzpykjl68+jcJyUem82hbTVIGaMCpvhx8VRqEr5AEXCXdbDbojw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.901.0",
-        "@aws-sdk/credential-provider-http": "3.901.0",
-        "@aws-sdk/credential-provider-ini": "3.901.0",
-        "@aws-sdk/credential-provider-process": "3.901.0",
-        "@aws-sdk/credential-provider-sso": "3.901.0",
-        "@aws-sdk/credential-provider-web-identity": "3.901.0",
+        "@aws-sdk/credential-provider-env": "3.907.0",
+        "@aws-sdk/credential-provider-http": "3.907.0",
+        "@aws-sdk/credential-provider-ini": "3.907.0",
+        "@aws-sdk/credential-provider-process": "3.907.0",
+        "@aws-sdk/credential-provider-sso": "3.907.0",
+        "@aws-sdk/credential-provider-web-identity": "3.907.0",
         "@aws-sdk/types": "3.901.0",
         "@smithy/credential-provider-imds": "^4.2.0",
         "@smithy/property-provider": "^4.2.0",
@@ -374,12 +374,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.901.0.tgz",
-      "integrity": "sha512-/IWgmgM3Cl1wTdJA5HqKMAojxLkYchh5kDuphApxKhupLu6Pu0JBOHU8A5GGeFvOycyaVwosod6zDduINZxe+A==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.907.0.tgz",
+      "integrity": "sha512-MBWpZqZtKkpM/LOGD5quXvlHJJN8YIP4GKo2ad8y1fEEVydwI8cggyXuauMPV7GllW8d0u3kQUs+4rxm1VaS4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/core": "3.907.0",
         "@aws-sdk/types": "3.901.0",
         "@smithy/property-provider": "^4.2.0",
         "@smithy/shared-ini-file-loader": "^4.3.0",
@@ -391,14 +391,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.901.0.tgz",
-      "integrity": "sha512-SjmqZQHmqFSET7+6xcZgtH7yEyh5q53LN87GqwYlJZ6KJ5oNw11acUNEhUOL1xTSJEvaWqwTIkS2zqrzLcM9bw==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.907.0.tgz",
+      "integrity": "sha512-F8I7xwIt0mhdg8NrC70HDmhDRx3ValBvmWH3YkWsjZltWIFozhQCCDISRPhanMkXVhSFmZY0FJ5Lo+B/SZvAAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.901.0",
-        "@aws-sdk/core": "3.901.0",
-        "@aws-sdk/token-providers": "3.901.0",
+        "@aws-sdk/client-sso": "3.907.0",
+        "@aws-sdk/core": "3.907.0",
+        "@aws-sdk/token-providers": "3.907.0",
         "@aws-sdk/types": "3.901.0",
         "@smithy/property-provider": "^4.2.0",
         "@smithy/shared-ini-file-loader": "^4.3.0",
@@ -410,13 +410,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.901.0.tgz",
-      "integrity": "sha512-NYjy/6NLxH9m01+pfpB4ql8QgAorJcu8tw69kzHwUd/ql6wUDTbC7HcXqtKlIwWjzjgj2BKL7j6SyFapgCuafA==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.907.0.tgz",
+      "integrity": "sha512-1CmRE/M8LJ/joXm5vUsKkQS35MoWA4xvUH9J1jyCuL3J9A8M+bnTe6ER8fnNLgmEs6ikdmYEIdfijPpBjBpFig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.901.0",
-        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/core": "3.907.0",
+        "@aws-sdk/nested-clients": "3.907.0",
         "@aws-sdk/types": "3.901.0",
         "@smithy/property-provider": "^4.2.0",
         "@smithy/shared-ini-file-loader": "^4.3.0",
@@ -473,12 +473,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.901.0.tgz",
-      "integrity": "sha512-Zby4F03fvD9xAgXGPywyk4bC1jCbnyubMEYChLYohD+x20ULQCf+AimF/Btn7YL+hBpzh1+RmqmvZcx+RgwgNQ==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.907.0.tgz",
+      "integrity": "sha512-j/h3lk4X6AAXvusx/h8rr0zlo7G0l0quZM4k4rS/9jzatI53HCsrMaiGu6YXbxuVqtfMqv0MAj0MVhaMsAIs4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/core": "3.907.0",
         "@aws-sdk/types": "3.901.0",
         "@aws-sdk/util-endpoints": "3.901.0",
         "@smithy/core": "^3.14.0",
@@ -491,23 +491,23 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.901.0.tgz",
-      "integrity": "sha512-feAAAMsVwctk2Tms40ONybvpfJPLCmSdI+G+OTrNpizkGLNl6ik2Ng2RzxY6UqOfN8abqKP/DOUj1qYDRDG8ag==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.907.0.tgz",
+      "integrity": "sha512-LycXsdC5sMIc+Az5z1Mo2eYShr2kLo2gUgx7Rja3udG0GdqgdR/NNJ6ArmDCeKk2O5RFS5EgEg89bT55ecl5Uw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/core": "3.907.0",
         "@aws-sdk/middleware-host-header": "3.901.0",
         "@aws-sdk/middleware-logger": "3.901.0",
         "@aws-sdk/middleware-recursion-detection": "3.901.0",
-        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.907.0",
         "@aws-sdk/region-config-resolver": "3.901.0",
         "@aws-sdk/types": "3.901.0",
         "@aws-sdk/util-endpoints": "3.901.0",
-        "@aws-sdk/util-user-agent-browser": "3.901.0",
-        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.907.0",
+        "@aws-sdk/util-user-agent-node": "3.907.0",
         "@smithy/config-resolver": "^4.3.0",
         "@smithy/core": "^3.14.0",
         "@smithy/fetch-http-handler": "^5.3.0",
@@ -557,13 +557,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.901.0.tgz",
-      "integrity": "sha512-pJEr1Ggbc/uVTDqp9IbNu9hdr0eQf3yZix3s4Nnyvmg4xmJSGAlbPC9LrNr5u3CDZoc8Z9CuLrvbP4MwYquNpQ==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.907.0.tgz",
+      "integrity": "sha512-HjPbNft1Ad8X1lHQG21QXy9pitdXA+OKH6NtcXg57A31002tM+SkyUmU6ty1jbsRBEScxziIVe5doI1NmkHheA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.901.0",
-        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/core": "3.907.0",
+        "@aws-sdk/nested-clients": "3.907.0",
         "@aws-sdk/types": "3.901.0",
         "@smithy/property-provider": "^4.2.0",
         "@smithy/shared-ini-file-loader": "^4.3.0",
@@ -616,9 +616,9 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.901.0.tgz",
-      "integrity": "sha512-Ntb6V/WFI21Ed4PDgL/8NSfoZQQf9xzrwNgiwvnxgAl/KvAvRBgQtqj5gHsDX8Nj2YmJuVoHfH9BGjL9VQ4WNg==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.907.0.tgz",
+      "integrity": "sha512-Hus/2YCQmtCEfr4Ls88d07Q99Ex59uvtktiPTV963Q7w7LHuIT/JBjrbwNxtSm2KlJR9PHNdqxwN+fSuNsMGMQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.901.0",
@@ -628,12 +628,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.901.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.901.0.tgz",
-      "integrity": "sha512-l59KQP5TY7vPVUfEURc7P5BJKuNg1RSsAKBQW7LHLECXjLqDUbo2SMLrexLBEoArSt6E8QOrIN0C8z/0Xk0jYw==",
+      "version": "3.907.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.907.0.tgz",
+      "integrity": "sha512-r2Bc8VCU6ymkuem+QWT6oDdGvaYnK0YHg77SGUF47k+JsztSt1kZR0Y0q8jRH97bOsXldThyEcYsNbqDERa1Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.907.0",
         "@aws-sdk/types": "3.901.0",
         "@smithy/node-config-provider": "^4.3.0",
         "@smithy/types": "^4.6.0",
@@ -2163,9 +2163,9 @@
       }
     },
     "node_modules/@nuxt/cli": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.29.0.tgz",
-      "integrity": "sha512-qqToeBZPGCkMYJvHR/8j/qzmZwnLs2EVTV5eBalA5CfX8+NTdR1uqrhtHcZXO3vySoODFjzCCVIK5a6chtyeQQ==",
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.29.3.tgz",
+      "integrity": "sha512-48GYmH4SyzR5pqd02UXVzBfrvEGaurPKMjSWxlHgqnpI5buwOYCvH+OqvHOmvnLrDP2bxR9hbDod/UIphOjMhg==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.0",
@@ -4117,9 +4117,9 @@
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4158,18 +4158,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.14.0.tgz",
-      "integrity": "sha512-XJ4z5FxvY/t0Dibms/+gLJrI5niRoY0BCmE02fwmPcRYFPI4KI876xaE79YGWIKnEslMbuQPsIEsoU/DXa0DoA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.15.0.tgz",
+      "integrity": "sha512-VJWncXgt+ExNn0U2+Y7UywuATtRYaodGQKFo9mDyh70q+fJGedfrqi2XuKU1BhiLeXgg6RZrW7VEKfeqFhHAJA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.2.0",
         "@smithy/protocol-http": "^5.3.0",
         "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-middleware": "^4.2.0",
-        "@smithy/util-stream": "^4.4.0",
+        "@smithy/util-stream": "^4.5.0",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
@@ -4195,15 +4195,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.0.tgz",
-      "integrity": "sha512-BG3KSmsx9A//KyIfw+sqNmWFr1YBUr+TwpxFT7yPqAk0yyDh7oSNgzfNH7pS6OC099EGx2ltOULvumCFe8bcgw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.1.tgz",
+      "integrity": "sha512-3AvYYbB+Dv5EPLqnJIAgYw/9+WzeBiUYS8B+rU0pHq5NMQMvrZmevUROS4V2GAt0jEOn9viBzPLrZE+riTNd5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.0",
         "@smithy/querystring-builder": "^4.2.0",
         "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4265,12 +4265,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.0.tgz",
-      "integrity": "sha512-jFVjuQeV8TkxaRlcCNg0GFVgg98tscsmIrIwRFeC74TIUyLE3jmY9xgc1WXrPQYRjQNK3aRoaIk6fhFRGOIoGw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.1.tgz",
+      "integrity": "sha512-JtM4SjEgImLEJVXdsbvWHYiJ9dtuKE8bqLlvkvGi96LbejDL6qnVpVxEFUximFodoQbg0Gnkyff9EKUhFhVJFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.14.0",
+        "@smithy/core": "^3.15.0",
         "@smithy/middleware-serde": "^4.2.0",
         "@smithy/node-config-provider": "^4.3.0",
         "@smithy/shared-ini-file-loader": "^4.3.0",
@@ -4284,15 +4284,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.0.tgz",
-      "integrity": "sha512-yaVBR0vQnOnzex45zZ8ZrPzUnX73eUC8kVFaAAbn04+6V7lPtxn56vZEBBAhgS/eqD6Zm86o6sJs6FuQVoX5qg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.1.tgz",
+      "integrity": "sha512-wXxS4ex8cJJteL0PPQmWYkNi9QKDWZIpsndr0wZI2EL+pSSvA/qqxXU60gBOJoIc2YgtZSWY/PE86qhKCCKP1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.0",
         "@smithy/protocol-http": "^5.3.0",
         "@smithy/service-error-classification": "^4.2.0",
-        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/smithy-client": "^4.7.1",
         "@smithy/types": "^4.6.0",
         "@smithy/util-middleware": "^4.2.0",
         "@smithy/util-retry": "^4.2.0",
@@ -4459,17 +4459,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.7.0.tgz",
-      "integrity": "sha512-3BDx/aCCPf+kkinYf5QQhdQ9UAGihgOVqI3QO5xQfSaIWvUE4KYLtiGRWsNe1SR7ijXC0QEPqofVp5Sb0zC8xQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.7.1.tgz",
+      "integrity": "sha512-WXVbiyNf/WOS/RHUoFMkJ6leEVpln5ojCjNBnzoZeMsnCg3A0BRhLK3WYc4V7PmYcYPZh9IYzzAg9XcNSzYxYQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.14.0",
-        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/core": "^3.15.0",
+        "@smithy/middleware-endpoint": "^4.3.1",
         "@smithy/middleware-stack": "^4.2.0",
         "@smithy/protocol-http": "^5.3.0",
         "@smithy/types": "^4.6.0",
-        "@smithy/util-stream": "^4.4.0",
+        "@smithy/util-stream": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4503,9 +4503,9 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.2.0.tgz",
-      "integrity": "sha512-+erInz8WDv5KPe7xCsJCp+1WCjSbah9gWcmUXc9NqmhyPx59tf7jqFz+za1tRG1Y5KM1Cy1rWCcGypylFp4mvA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.0",
@@ -4529,9 +4529,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.0.tgz",
-      "integrity": "sha512-U8q1WsSZFjXijlD7a4wsDQOvOwV+72iHSfq1q7VD+V75xP/pdtm0WIGuaFJ3gcADDOKj2MIBn4+zisi140HEnQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4566,15 +4566,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.2.0.tgz",
-      "integrity": "sha512-qzHp7ZDk1Ba4LDwQVCNp90xPGqSu7kmL7y5toBpccuhi3AH7dcVBIT/pUxYcInK4jOy6FikrcTGq5wxcka8UaQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.0.tgz",
+      "integrity": "sha512-H4MAj8j8Yp19Mr7vVtGgi7noJjvjJbsKQJkvNnLlrIFduRFT5jq5Eri1k838YW7rN2g5FTnXpz5ktKVr1KVgPQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.0",
-        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/smithy-client": "^4.7.1",
         "@smithy/types": "^4.6.0",
-        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4582,16 +4581,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.0.tgz",
-      "integrity": "sha512-FxUHS3WXgx3bTWR6yQHNHHkQHZm/XKIi/CchTnKvBulN6obWpcbzJ6lDToXn+Wp0QlVKd7uYAz2/CTw1j7m+Kg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.1.tgz",
+      "integrity": "sha512-PuDcgx7/qKEMzV1QFHJ7E4/MMeEjaA7+zS5UNcHCLPvvn59AeZQ0DSDGMpqC2xecfa/1cNGm4l8Ec/VxCuY7Ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.3.0",
         "@smithy/credential-provider-imds": "^4.2.0",
         "@smithy/node-config-provider": "^4.3.0",
         "@smithy/property-provider": "^4.2.0",
-        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/smithy-client": "^4.7.1",
         "@smithy/types": "^4.6.0",
         "tslib": "^2.6.2"
       },
@@ -4653,15 +4652,15 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.4.0.tgz",
-      "integrity": "sha512-vtO7ktbixEcrVzMRmpQDnw/Ehr9UWjBvSJ9fyAbadKkC4w5Cm/4lMO8cHz8Ysb8uflvQUNRcuux/oNHKPXkffg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.0.tgz",
+      "integrity": "sha512-0TD5M5HCGu5diEvZ/O/WquSjhJPasqv7trjoqHyWjNh/FBeBl7a0ztl9uFMOsauYtRfd8jvpzIAQhDHbx+nvZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/fetch-http-handler": "^5.3.1",
         "@smithy/node-http-handler": "^4.3.0",
         "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-base64": "^4.3.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
@@ -4833,9 +4832,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
-      "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
+      "version": "24.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.1.tgz",
+      "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.14.0"
@@ -4937,13 +4936,13 @@
       "optional": true
     },
     "node_modules/@unhead/vue": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.0.17.tgz",
-      "integrity": "sha512-jzmGZYeMAhETV6qfetmLbZzUjjx1TjdNvFSobeFZb73D7dwD9wl/nOAx36qq+TvjZsLJdF5PQWToz2oDGAUqCg==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.0.19.tgz",
+      "integrity": "sha512-7BYjHfOaoZ9+ARJkT10Q2TjnTUqDXmMpfakIAsD/hXiuff1oqWg1xeXT5+MomhNcC15HbiABpbbBmITLSHxdKg==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^5.5.3",
-        "unhead": "2.0.17"
+        "unhead": "2.0.19"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
@@ -5676,9 +5675,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.12.tgz",
-      "integrity": "sha512-vAPMQdnyKCBtkmQA6FMCBvU9qFIppS3nzyXnEM+Lo2IAhG4Mpjv9cCxMudhgV3YdNNJv6TNqXy97dfRVL2LmaQ==",
+      "version": "2.8.15",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.15.tgz",
+      "integrity": "sha512-qsJ8/X+UypqxHXN75M7dF88jNK37dLBRW7LeUzCPz+TNs37G8cfWy9nWzS+LS//g600zrt2le9KuXt0rWfDz5Q==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -5916,9 +5915,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001748",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001748.tgz",
-      "integrity": "sha512-5P5UgAr0+aBmNiplks08JLw+AW/XG/SurlgZLgB1dDLfAw7EfRGxIwzPHxdSCGY/BTKDqIVyJL87cCN6s0ZR0w==",
+      "version": "1.0.30001749",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001749.tgz",
+      "integrity": "sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -6026,18 +6025,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6419,9 +6406,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.45.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
-      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
+      "integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6958,15 +6945,15 @@
       }
     },
     "node_modules/dot-prop": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
-      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
+      "integrity": "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==",
       "license": "MIT",
       "dependencies": {
-        "type-fest": "^4.18.2"
+        "type-fest": "^5.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7166,9 +7153,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.232",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.232.tgz",
-      "integrity": "sha512-ENirSe7wf8WzyPCibqKUG1Cg43cPaxH4wRR7AJsX7MCABCHBIOFqvaYODSLKUuZdraxUTHRE/0A2Aq8BYKEHOg==",
+      "version": "1.5.234",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.234.tgz",
+      "integrity": "sha512-RXfEp2x+VRYn8jbKfQlRImzoJU01kyDvVPBmG39eU2iuRVhuS6vQNocB8J0/8GrIMLnPzgz4eW6WiRnJkTuNWg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -7786,9 +7773,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
-      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.12.0.tgz",
+      "integrity": "sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==",
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7881,20 +7868,20 @@
       }
     },
     "node_modules/globby": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-15.0.0.tgz",
+      "integrity": "sha512-oB4vkQGqlMl682wL1IlWd02tXCbquGWM4voPEI85QmNKCaw8zGTm1f1rubFgkg3Eli2PtKlFgrnmUqasbQWlkw==",
       "license": "MIT",
       "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
+        "@sindresorhus/merge-streams": "^4.0.0",
         "fast-glob": "^3.3.3",
-        "ignore": "^7.0.3",
+        "ignore": "^7.0.5",
         "path-type": "^6.0.0",
         "slash": "^5.1.0",
         "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8118,9 +8105,9 @@
       }
     },
     "node_modules/image-meta": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.2.1.tgz",
-      "integrity": "sha512-K6acvFaelNxx8wc2VjbIzXKDVB0Khs0QT35U6NkGfTdCmjLNcO2945m7RFNR9/RPVFm48hq7QPzK8uGH18HCGw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.2.2.tgz",
+      "integrity": "sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==",
       "license": "MIT"
     },
     "node_modules/impound": {
@@ -9111,9 +9098,9 @@
       "license": "MIT"
     },
     "node_modules/nitropack": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/nitropack/-/nitropack-2.12.6.tgz",
-      "integrity": "sha512-DEq31s0SP4/Z5DIoVBRo9DbWFPWwIoYD4cQMEz7eE+iJMiAP+1k9A3B9kcc6Ihc0jDJmfUcHYyh6h2XlynCx6g==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/nitropack/-/nitropack-2.12.7.tgz",
+      "integrity": "sha512-HWyzMBj2d8b14J6Cfnxv97ztnuHIgXNcrGiWCruLfb2ZfKsp6OCbZYJm5T9sv/ZKl8LedhatrMKG66HWJux9Rg==",
       "license": "MIT",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.4.0",
@@ -9121,12 +9108,12 @@
         "@rollup/plugin-commonjs": "^28.0.6",
         "@rollup/plugin-inject": "^5.0.5",
         "@rollup/plugin-json": "^6.1.0",
-        "@rollup/plugin-node-resolve": "^16.0.1",
+        "@rollup/plugin-node-resolve": "^16.0.2",
         "@rollup/plugin-replace": "^6.0.2",
         "@rollup/plugin-terser": "^0.4.4",
-        "@vercel/nft": "^0.30.1",
+        "@vercel/nft": "^0.30.2",
         "archiver": "^7.0.1",
-        "c12": "^3.2.0",
+        "c12": "^3.3.0",
         "chokidar": "^4.0.3",
         "citty": "^0.1.6",
         "compatx": "^0.2.0",
@@ -9135,27 +9122,27 @@
         "cookie-es": "^2.0.0",
         "croner": "^9.1.0",
         "crossws": "^0.3.5",
-        "db0": "^0.3.2",
+        "db0": "^0.3.4",
         "defu": "^6.1.4",
         "destr": "^2.0.5",
-        "dot-prop": "^9.0.0",
-        "esbuild": "^0.25.9",
+        "dot-prop": "^10.1.0",
+        "esbuild": "^0.25.10",
         "escape-string-regexp": "^5.0.0",
         "etag": "^1.8.1",
         "exsolve": "^1.0.7",
-        "globby": "^14.1.0",
+        "globby": "^15.0.0",
         "gzip-size": "^7.0.0",
         "h3": "^1.15.4",
         "hookable": "^5.5.3",
         "httpxy": "^0.1.7",
-        "ioredis": "^5.7.0",
-        "jiti": "^2.5.1",
+        "ioredis": "^5.8.1",
+        "jiti": "^2.6.1",
         "klona": "^2.0.6",
         "knitwork": "^1.2.0",
         "listhen": "^1.9.0",
         "magic-string": "^0.30.19",
         "magicast": "^0.3.5",
-        "mime": "^4.0.7",
+        "mime": "^4.1.0",
         "mlly": "^1.8.0",
         "node-fetch-native": "^1.6.7",
         "node-mock-http": "^1.0.3",
@@ -9164,10 +9151,10 @@
         "pathe": "^2.0.3",
         "perfect-debounce": "^2.0.0",
         "pkg-types": "^2.3.0",
-        "pretty-bytes": "^7.0.1",
+        "pretty-bytes": "^7.1.0",
         "radix3": "^1.1.2",
-        "rollup": "^4.50.1",
-        "rollup-plugin-visualizer": "^6.0.3",
+        "rollup": "^4.52.4",
+        "rollup-plugin-visualizer": "^6.0.4",
         "scule": "^1.3.0",
         "semver": "^7.7.2",
         "serve-placeholder": "^2.0.2",
@@ -9179,12 +9166,12 @@
         "uncrypto": "^0.1.3",
         "unctx": "^2.4.1",
         "unenv": "^2.0.0-rc.21",
-        "unimport": "^5.2.0",
-        "unplugin-utils": "^0.3.0",
+        "unimport": "^5.4.1",
+        "unplugin-utils": "^0.3.1",
         "unstorage": "^1.17.1",
         "untyped": "^2.0.0",
         "unwasm": "^0.3.11",
-        "youch": "^4.1.0-beta.11",
+        "youch": "4.1.0-beta.11",
         "youch-core": "^0.3.3"
       },
       "bin": {
@@ -10879,9 +10866,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11117,9 +11104,9 @@
       }
     },
     "node_modules/srvx": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.8.9.tgz",
-      "integrity": "sha512-wYc3VLZHRzwYrWJhkEqkhLb31TI0SOkfYZDkUhXdp3NoCnNS0FqajiQszZZjfow/VYEuc6Q5sZh9nM6kPy2NBQ==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.8.15.tgz",
+      "integrity": "sha512-poPs1GuctQLpiJ/1Pb8e+5b5lju9hQU7wxJ6NkYVUw7ZZExeRoYwyiaOekal+rDZc99MO/J2y9+SGFpHBKRSpQ==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^2.0.0"
@@ -11445,6 +11432,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
@@ -11627,12 +11626,15 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.0.1.tgz",
+      "integrity": "sha512-9MpwAI52m8H6ssA542UxSLnSiSD2dsC3/L85g6hVubLSXd82wdI80eZwTWhdOfN67NlA+D+oipAs1MlcTcu3KA==",
       "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11722,9 +11724,9 @@
       }
     },
     "node_modules/unhead": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.0.17.tgz",
-      "integrity": "sha512-xX3PCtxaE80khRZobyWCVxeFF88/Tg9eJDcJWY9us727nsTC7C449B8BUfVBmiF2+3LjPcmqeoB2iuMs0U4oJQ==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.0.19.tgz",
+      "integrity": "sha512-gEEjkV11Aj+rBnY6wnRfsFtF2RxKOLaPN4i+Gx3UhBxnszvV6ApSNZbGk7WKyy/lErQ6ekPN63qdFL7sa1leow==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^5.5.3"


### PR DESCRIPTION
## 自动依赖更新

- 触发时间: 2025-10-10
- 工作流: dependency-update.yml
- Node.js 版本: 18

<details>
<summary>📋 详细更新信息（点击展开）</summary>

#### 更新的文件
- package-lock.json 已更新



#### 安全审计结果
```
正在运行安全审计...

# npm audit report

esbuild  <=0.24.2
Severity: moderate
esbuild enables any website to send any requests to the development server and read the response - https://github.com/advisories/GHSA-67mh-4wv8-2f99
fix available via `npm audit fix --force`
Will install drizzle-kit@0.18.1, which is a breaking change
node_modules/@esbuild-kit/core-utils/node_modules/esbuild
  @esbuild-kit/core-utils  *
  Depends on vulnerable versions of esbuild
  node_modules/@esbuild-kit/core-utils
    @esbuild-kit/esm-loader  *
    Depends on vulnerable versions of @esbuild-kit/core-utils
    node_modules/@esbuild-kit/esm-loader
      drizzle-kit  0.17.5-6b7793f - 0.17.5-e5944eb || 0.18.1-065de38 - 0.18.1-f3800bf || >=0.19.0-07024c4
      Depends on vulnerable versions of @esbuild-kit/esm-loader
      node_modules/drizzle-kit

nodemailer  <7.0.7
Severity: moderate
Nodemailer: Email to an unintended domain can occur due to Interpretation Conflict - https://github.com/advisories/GHSA-mm7p-fcc7-pg87
fix available via `npm audit fix --force`
Will install nodemailer@7.0.9, which is a breaking change
node_modules/nodemailer

xlsx  *
Severity: high
Prototype Pollution in sheetJS - https://github.com/advisories/GHSA-4r6h-8v6p-xvw6
SheetJS Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-5pgg-2g8v-p4x9
No fix available
node_modules/xlsx

6 vulnerabilities (5 moderate, 1 high)

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

--- 审计摘要 ---
总计发现: 6 vulnerabilities
漏洞详情:
esbuild  <=0.24.2
Severity: moderate
esbuild enables any website to send any requests to the development server and read the response - https://github.com/advisories/GHSA-67mh-4wv8-2f99
fix available via `npm audit fix --force`
--
nodemailer  <7.0.7
Severity: moderate
Nodemailer: Email to an unintended domain can occur due to Interpretation Conflict - https://github.com/advisories/GHSA-mm7p-fcc7-pg87
fix available via `npm audit fix --force`
--
```

</details>