### PR TITLE
自动依赖更新 - 2026-01-10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -218,45 +218,45 @@
       }
     },
     "node_modules/@aws-sdk/client-ses": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.965.0.tgz",
-      "integrity": "sha512-RZXJBoHA3I6Ts1/bjOLDceT0hbK00lVkXAXFpcz5At+p6Yu52jVmdAdKDmLuf1IgCDw7s2IsrR4Us2Od1AabCg==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.966.0.tgz",
+      "integrity": "sha512-UZbcBAXX0gHpfSAS3zCH9278o9t0JNKl3olMo94NWIk0l/EiDPF15wRYVpTvp0db7KD+MfkdtHDkH4zk/EbS7w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.965.0",
-        "@aws-sdk/credential-provider-node": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
+        "@aws-sdk/credential-provider-node": "3.966.0",
         "@aws-sdk/middleware-host-header": "3.965.0",
         "@aws-sdk/middleware-logger": "3.965.0",
         "@aws-sdk/middleware-recursion-detection": "3.965.0",
-        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/middleware-user-agent": "3.966.0",
         "@aws-sdk/region-config-resolver": "3.965.0",
         "@aws-sdk/types": "3.965.0",
         "@aws-sdk/util-endpoints": "3.965.0",
         "@aws-sdk/util-user-agent-browser": "3.965.0",
-        "@aws-sdk/util-user-agent-node": "3.965.0",
+        "@aws-sdk/util-user-agent-node": "3.966.0",
         "@smithy/config-resolver": "^4.4.5",
-        "@smithy/core": "^3.20.0",
+        "@smithy/core": "^3.20.1",
         "@smithy/fetch-http-handler": "^5.3.8",
         "@smithy/hash-node": "^4.2.7",
         "@smithy/invalid-dependency": "^4.2.7",
         "@smithy/middleware-content-length": "^4.2.7",
-        "@smithy/middleware-endpoint": "^4.4.1",
-        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-endpoint": "^4.4.2",
+        "@smithy/middleware-retry": "^4.4.18",
         "@smithy/middleware-serde": "^4.2.8",
         "@smithy/middleware-stack": "^4.2.7",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/node-http-handler": "^4.4.7",
         "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/smithy-client": "^4.10.3",
         "@smithy/types": "^4.11.0",
         "@smithy/url-parser": "^4.2.7",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.16",
-        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-defaults-mode-browser": "^4.3.17",
+        "@smithy/util-defaults-mode-node": "^4.2.20",
         "@smithy/util-endpoints": "^3.2.7",
         "@smithy/util-middleware": "^4.2.7",
         "@smithy/util-retry": "^4.2.7",
@@ -269,44 +269,44 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.965.0.tgz",
-      "integrity": "sha512-iv2tr+n4aZ+nPUFFvG00hISPuEd4DU+1/Q8rPAYKXsM+vEPJ2nAnP5duUOa2fbOLIUCRxX3dcQaQaghVHDHzQw==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.966.0.tgz",
+      "integrity": "sha512-hQZDQgqRJclALDo9wK+bb5O+VpO8JcjImp52w9KPSz9XveNRgE9AYfklRJd8qT2Bwhxe6IbnqYEino2wqUMA1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
         "@aws-sdk/middleware-host-header": "3.965.0",
         "@aws-sdk/middleware-logger": "3.965.0",
         "@aws-sdk/middleware-recursion-detection": "3.965.0",
-        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/middleware-user-agent": "3.966.0",
         "@aws-sdk/region-config-resolver": "3.965.0",
         "@aws-sdk/types": "3.965.0",
         "@aws-sdk/util-endpoints": "3.965.0",
         "@aws-sdk/util-user-agent-browser": "3.965.0",
-        "@aws-sdk/util-user-agent-node": "3.965.0",
+        "@aws-sdk/util-user-agent-node": "3.966.0",
         "@smithy/config-resolver": "^4.4.5",
-        "@smithy/core": "^3.20.0",
+        "@smithy/core": "^3.20.1",
         "@smithy/fetch-http-handler": "^5.3.8",
         "@smithy/hash-node": "^4.2.7",
         "@smithy/invalid-dependency": "^4.2.7",
         "@smithy/middleware-content-length": "^4.2.7",
-        "@smithy/middleware-endpoint": "^4.4.1",
-        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-endpoint": "^4.4.2",
+        "@smithy/middleware-retry": "^4.4.18",
         "@smithy/middleware-serde": "^4.2.8",
         "@smithy/middleware-stack": "^4.2.7",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/node-http-handler": "^4.4.7",
         "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/smithy-client": "^4.10.3",
         "@smithy/types": "^4.11.0",
         "@smithy/url-parser": "^4.2.7",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.16",
-        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-defaults-mode-browser": "^4.3.17",
+        "@smithy/util-defaults-mode-node": "^4.2.20",
         "@smithy/util-endpoints": "^3.2.7",
         "@smithy/util-middleware": "^4.2.7",
         "@smithy/util-retry": "^4.2.7",
@@ -318,19 +318,19 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.965.0.tgz",
-      "integrity": "sha512-aq9BhQxdHit8UUJ9C0im9TtuKeK0pT6NXmNJxMTCFeStI7GG7ImIsSislg3BZTIifVg1P6VLdzMyz9de85iutQ==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.966.0.tgz",
+      "integrity": "sha512-QaRVBHD1prdrFXIeFAY/1w4b4S0EFyo/ytzU+rCklEjMRT7DKGXGoHXTWLGz+HD7ovlS5u+9cf8a/LeSOEMzww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.965.0",
         "@aws-sdk/xml-builder": "3.965.0",
-        "@smithy/core": "^3.20.0",
+        "@smithy/core": "^3.20.1",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/protocol-http": "^5.3.7",
         "@smithy/signature-v4": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/smithy-client": "^4.10.3",
         "@smithy/types": "^4.11.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-middleware": "^4.2.7",
@@ -342,12 +342,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.965.0.tgz",
-      "integrity": "sha512-mdGnaIjMxTIjsb70dEj3VsWPWpoq1V5MWzBSfJq2H8zgMBXjn6d5/qHP8HMf53l9PrsgqzMpXGv3Av549A2x1g==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.966.0.tgz",
+      "integrity": "sha512-sxVKc9PY0SH7jgN/8WxhbKQ7MWDIgaJv1AoAKJkhJ+GM5r09G5Vb2Vl8ALYpsy+r8b+iYpq5dGJj8k2VqxoQMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/types": "^4.11.0",
@@ -358,18 +358,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.965.0.tgz",
-      "integrity": "sha512-YuGQel9EgA/z25oeLM+GYYQS750+8AESvr7ZEmVnRPL0sg+K3DmGqdv+9gFjFd0UkLjTlC/jtbP2cuY6UcPiHQ==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.966.0.tgz",
+      "integrity": "sha512-VTJDP1jOibVtc5pn5TNE12rhqOO/n10IjkoJi8fFp9BMfmh3iqo70Ppvphz/Pe/R9LcK5Z3h0Z4EB9IXDR6kag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@smithy/fetch-http-handler": "^5.3.8",
         "@smithy/node-http-handler": "^4.4.7",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/smithy-client": "^4.10.3",
         "@smithy/types": "^4.11.0",
         "@smithy/util-stream": "^4.5.8",
         "tslib": "^2.6.2"
@@ -379,19 +379,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.965.0.tgz",
-      "integrity": "sha512-xRo72Prer5s0xYVSCxCymVIRSqrVlevK5cmU0GWq9yJtaBNpnx02jwdJg80t/Ni7pgbkQyFWRMcq38c1tc6M/w==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.966.0.tgz",
+      "integrity": "sha512-4oQKkYMCUx0mffKuH8LQag1M4Fo5daKVmsLAnjrIqKh91xmCrcWlAFNMgeEYvI1Yy125XeNSaFMfir6oNc2ODA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.965.0",
-        "@aws-sdk/credential-provider-env": "3.965.0",
-        "@aws-sdk/credential-provider-http": "3.965.0",
-        "@aws-sdk/credential-provider-login": "3.965.0",
-        "@aws-sdk/credential-provider-process": "3.965.0",
-        "@aws-sdk/credential-provider-sso": "3.965.0",
-        "@aws-sdk/credential-provider-web-identity": "3.965.0",
-        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
+        "@aws-sdk/credential-provider-env": "3.966.0",
+        "@aws-sdk/credential-provider-http": "3.966.0",
+        "@aws-sdk/credential-provider-login": "3.966.0",
+        "@aws-sdk/credential-provider-process": "3.966.0",
+        "@aws-sdk/credential-provider-sso": "3.966.0",
+        "@aws-sdk/credential-provider-web-identity": "3.966.0",
+        "@aws-sdk/nested-clients": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@smithy/credential-provider-imds": "^4.2.7",
         "@smithy/property-provider": "^4.2.7",
@@ -404,13 +404,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.965.0.tgz",
-      "integrity": "sha512-43/H8Qku8LHyugbhLo8kjD+eauhybCeVkmrnvWl8bXNHJP7xi1jCdtBQJKKJqiIHZws4MOEwkji8kFdAVRCe6g==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.966.0.tgz",
+      "integrity": "sha512-wD1KlqLyh23Xfns/ZAPxebwXixoJJCuDbeJHFrLDpP4D4h3vA2S8nSFgBSFR15q9FhgRfHleClycf6g5K4Ww6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.965.0",
-        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
+        "@aws-sdk/nested-clients": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/protocol-http": "^5.3.7",
@@ -423,17 +423,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.965.0.tgz",
-      "integrity": "sha512-cRxmMHF+Zh2lkkkEVduKl+8OQdtg/DhYA69+/7SPSQURlgyjFQGlRQ58B7q8abuNlrGT3sV+UzeOylZpJbV61Q==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.966.0.tgz",
+      "integrity": "sha512-7QCOERGddMw7QbjE+LSAFgwOBpPv4px2ty0GCK7ZiPJGsni2EYmM4TtYnQb9u1WNHmHqIPWMbZR0pKDbyRyHlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.965.0",
-        "@aws-sdk/credential-provider-http": "3.965.0",
-        "@aws-sdk/credential-provider-ini": "3.965.0",
-        "@aws-sdk/credential-provider-process": "3.965.0",
-        "@aws-sdk/credential-provider-sso": "3.965.0",
-        "@aws-sdk/credential-provider-web-identity": "3.965.0",
+        "@aws-sdk/credential-provider-env": "3.966.0",
+        "@aws-sdk/credential-provider-http": "3.966.0",
+        "@aws-sdk/credential-provider-ini": "3.966.0",
+        "@aws-sdk/credential-provider-process": "3.966.0",
+        "@aws-sdk/credential-provider-sso": "3.966.0",
+        "@aws-sdk/credential-provider-web-identity": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@smithy/credential-provider-imds": "^4.2.7",
         "@smithy/property-provider": "^4.2.7",
@@ -446,12 +446,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.965.0.tgz",
-      "integrity": "sha512-gmkPmdiR0yxnTzLPDb7rwrDhGuCUjtgnj8qWP+m0gSz/W43rR4jRPVEf6DUX2iC+ImQhxo3NFhuB3V42Kzo3TQ==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.966.0.tgz",
+      "integrity": "sha512-q5kCo+xHXisNbbPAh/DiCd+LZX4wdby77t7GLk0b2U0/mrel4lgy6o79CApe+0emakpOS1nPZS7voXA7vGPz4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -463,14 +463,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.965.0.tgz",
-      "integrity": "sha512-N01AYvtCqG3Wo/s/LvYt19ity18/FqggiXT+elAs3X9Om/Wfx+hw9G+i7jaDmy+/xewmv8AdQ2SK5Q30dXw/Fw==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.966.0.tgz",
+      "integrity": "sha512-Rv5aEfbpqsQZzxpX2x+FbSyVFOE3Dngome+exNA8jGzc00rrMZEUnm3J3yAsLp/I2l7wnTfI0r2zMe+T9/nZAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.965.0",
-        "@aws-sdk/core": "3.965.0",
-        "@aws-sdk/token-providers": "3.965.0",
+        "@aws-sdk/client-sso": "3.966.0",
+        "@aws-sdk/core": "3.966.0",
+        "@aws-sdk/token-providers": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -482,13 +482,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.965.0.tgz",
-      "integrity": "sha512-T4gMZ2JzXnfxe1oTD+EDGLSxFfk1+WkLZdiHXEMZp8bFI1swP/3YyDFXI+Ib9Uq1JhnAmrCXtOnkicKEhDkdhQ==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.966.0.tgz",
+      "integrity": "sha512-Yv1lc9iic9xg3ywMmIAeXN1YwuvfcClLVdiF2y71LqUgIOupW8B8my84XJr6pmOQuKzZa++c2znNhC9lGsbKyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.965.0",
-        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
+        "@aws-sdk/nested-clients": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -545,15 +545,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.965.0.tgz",
-      "integrity": "sha512-RBEYVGgu/WeAt+H/qLrGc+t8LqAUkbyvh3wBfTiuAD+uBcWsKnvnB1iSBX75FearC0fmoxzXRUc0PMxMdqpjJQ==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.966.0.tgz",
+      "integrity": "sha512-MvGoy0vhMluVpSB5GaGJbYLqwbZfZjwEZhneDHdPhgCgQqmCtugnYIIjpUw7kKqWGsmaMQmNEgSFf1zYYmwOyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@aws-sdk/util-endpoints": "3.965.0",
-        "@smithy/core": "^3.20.0",
+        "@smithy/core": "^3.20.1",
         "@smithy/protocol-http": "^5.3.7",
         "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
@@ -563,44 +563,44 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.965.0.tgz",
-      "integrity": "sha512-muNVUjUEU+/KLFrLzQ8PMXyw4+a/MP6t4GIvwLtyx/kH0rpSy5s0YmqacMXheuIe6F/5QT8uksXGNAQenitkGQ==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.966.0.tgz",
+      "integrity": "sha512-FRzAWwLNoKiaEWbYhnpnfartIdOgiaBLnPcd3uG1Io+vvxQUeRPhQIy4EfKnT3AuA+g7gzSCjMG2JKoJOplDtQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
         "@aws-sdk/middleware-host-header": "3.965.0",
         "@aws-sdk/middleware-logger": "3.965.0",
         "@aws-sdk/middleware-recursion-detection": "3.965.0",
-        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/middleware-user-agent": "3.966.0",
         "@aws-sdk/region-config-resolver": "3.965.0",
         "@aws-sdk/types": "3.965.0",
         "@aws-sdk/util-endpoints": "3.965.0",
         "@aws-sdk/util-user-agent-browser": "3.965.0",
-        "@aws-sdk/util-user-agent-node": "3.965.0",
+        "@aws-sdk/util-user-agent-node": "3.966.0",
         "@smithy/config-resolver": "^4.4.5",
-        "@smithy/core": "^3.20.0",
+        "@smithy/core": "^3.20.1",
         "@smithy/fetch-http-handler": "^5.3.8",
         "@smithy/hash-node": "^4.2.7",
         "@smithy/invalid-dependency": "^4.2.7",
         "@smithy/middleware-content-length": "^4.2.7",
-        "@smithy/middleware-endpoint": "^4.4.1",
-        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-endpoint": "^4.4.2",
+        "@smithy/middleware-retry": "^4.4.18",
         "@smithy/middleware-serde": "^4.2.8",
         "@smithy/middleware-stack": "^4.2.7",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/node-http-handler": "^4.4.7",
         "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/smithy-client": "^4.10.3",
         "@smithy/types": "^4.11.0",
         "@smithy/url-parser": "^4.2.7",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.16",
-        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-defaults-mode-browser": "^4.3.17",
+        "@smithy/util-defaults-mode-node": "^4.2.20",
         "@smithy/util-endpoints": "^3.2.7",
         "@smithy/util-middleware": "^4.2.7",
         "@smithy/util-retry": "^4.2.7",
@@ -628,13 +628,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.965.0.tgz",
-      "integrity": "sha512-aR0qxg0b8flkXJVE+CM1gzo7uJ57md50z2eyCwofC0QIz5Y0P7/7vvb9/dmUQt6eT9XRN5iRcUqq2IVxVDvJOw==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.966.0.tgz",
+      "integrity": "sha512-8k5cBTicTGYJHhKaweO4gL4fud1KDnLS5fByT6/Xbiu59AxYM4E/h3ds+3jxDMnniCE3gIWpEnyfM9khtmw2lA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.965.0",
-        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/core": "3.966.0",
+        "@aws-sdk/nested-clients": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -699,12 +699,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.965.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.965.0.tgz",
-      "integrity": "sha512-kokIHUfNT3/P55E4fUJJrFHuuA9BbjFKUIxoLrd3UaRfdafT0ScRfg2eaZie6arf60EuhlUIZH0yALxttMEjxQ==",
+      "version": "3.966.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.966.0.tgz",
+      "integrity": "sha512-vPPe8V0GLj+jVS5EqFz2NUBgWH35favqxliUOvhp8xBdNRkEjiZm5TqitVtFlxS4RrLY3HOndrWbrP5ejbwl1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/middleware-user-agent": "3.966.0",
         "@aws-sdk/types": "3.965.0",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/types": "^4.11.0",
@@ -773,7 +773,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -4410,6 +4409,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.4.3.tgz",
       "integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/colord": "^2.9.6"
       }
@@ -4418,13 +4418,15 @@
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
       "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/constants": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.4.3.tgz",
       "integrity": "sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/core": {
       "version": "7.4.3",
@@ -4461,7 +4463,8 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.3.tgz",
       "integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/filter-blur": {
       "version": "7.4.3",
@@ -4497,19 +4500,22 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.4.3.tgz",
       "integrity": "sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/runner": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.3.tgz",
       "integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/settings": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.4.3.tgz",
       "integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/constants": "7.4.3",
         "@types/css-font-loading-module": "^0.0.12",
@@ -4532,6 +4538,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.4.3.tgz",
       "integrity": "sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/extensions": "7.4.3",
         "@pixi/settings": "7.4.3",
@@ -4543,6 +4550,7 @@
       "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.4.3.tgz",
       "integrity": "sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/color": "7.4.3",
         "@pixi/constants": "7.4.3",
@@ -4621,7 +4629,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.10.0.tgz",
       "integrity": "sha512-JXmM4XCoso6C75Mr3lhKA3eNxSzkYi3nCzxDIKY+YOszYsJjuKbFgVtguVPbLMOttN4iu2fXoc2BGhdnYhIOxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -5225,9 +5232,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.1.tgz",
-      "integrity": "sha512-wOboSEdQ85dbKAJ0zL+wQ6b0HTSBRhtGa0PYKysQXkRg+vK0tdCRRVruiFM2QMprkOQwSYOnwF4og96PAaEGag==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.2.tgz",
+      "integrity": "sha512-nc99TseyTwL1bg+T21cyEA5oItNy1XN4aUeyOlXJnvyRW5VSK1oRKRoSM/Iq0KFPuqZMxjBemSZHZCOZbSyBMw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.2.8",
@@ -5332,12 +5339,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.2.tgz",
-      "integrity": "sha512-mqpAdux0BNmZu/SqkFhQEnod4fX23xxTvU2LUpmKp0JpSI+kPYCiHJMmzREr8yxbNxKL2/DU1UZm9i++ayU+2g==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.3.tgz",
+      "integrity": "sha512-Zb8R35hjBhp1oFhiaAZ9QhClpPHdEDmNDC2UrrB2fqV0oNDUUPH12ovZHB5xi/Rd+pg/BJHOR1q+SfsieSKPQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.20.1",
+        "@smithy/core": "^3.20.2",
         "@smithy/middleware-serde": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -5351,15 +5358,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.18.tgz",
-      "integrity": "sha512-E5hulijA59nBk/zvcwVMaS7FG7Y4l6hWA9vrW018r+8kiZef4/ETQaPI4oY+3zsy9f6KqDv3c4VKtO4DwwgpCg==",
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.19.tgz",
+      "integrity": "sha512-QtisFIjIw2tjMm/ESatjWFVIQb5Xd093z8xhxq/SijLg7Mgo2C2wod47Ib/AHpBLFhwYXPzd7Hp2+JVXfeZyMQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/protocol-http": "^5.3.7",
         "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.3",
+        "@smithy/smithy-client": "^4.10.4",
         "@smithy/types": "^4.11.0",
         "@smithy/util-middleware": "^4.2.7",
         "@smithy/util-retry": "^4.2.7",
@@ -5526,13 +5533,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.3.tgz",
-      "integrity": "sha512-EfECiO/0fAfb590LBnUe7rI5ux7XfquQ8LBzTe7gxw0j9QW/q8UT/EHWHlxV/+jhQ3+Ssga9uUYXCQgImGMbNg==",
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.4.tgz",
+      "integrity": "sha512-rHig+BWjhjlHlah67ryaW9DECYixiJo5pQCTEwsJyarRBAwHMMC3iYz5MXXAHXe64ZAMn1NhTUSTFIu1T6n6jg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.20.1",
-        "@smithy/middleware-endpoint": "^4.4.2",
+        "@smithy/core": "^3.20.2",
+        "@smithy/middleware-endpoint": "^4.4.3",
         "@smithy/middleware-stack": "^4.2.7",
         "@smithy/protocol-http": "^5.3.7",
         "@smithy/types": "^4.11.0",
@@ -5633,13 +5640,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.17.tgz",
-      "integrity": "sha512-dwN4GmivYF1QphnP3xJESXKtHvkkvKHSZI8GrSKMVoENVSKW2cFPRYC4ZgstYjUHdR3zwaDkIaTDIp26JuY7Cw==",
+      "version": "4.3.18",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.18.tgz",
+      "integrity": "sha512-Ao1oLH37YmLyHnKdteMp6l4KMCGBeZEAN68YYe00KAaKFijFELDbRQRm3CNplz7bez1HifuBV0l5uR6eVJLhIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.3",
+        "@smithy/smithy-client": "^4.10.4",
         "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
@@ -5648,16 +5655,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.20",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.20.tgz",
-      "integrity": "sha512-VD/I4AEhF1lpB3B//pmOIMBNLMrtdMXwy9yCOfa2QkJGDr63vH3RqPbSAKzoGMov3iryCxTXCxSsyGmEB8PDpg==",
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.21.tgz",
+      "integrity": "sha512-e21ASJDirE96kKXZLcYcnn4Zt0WGOvMYc1P8EK0gQeQ3I8PbJWqBKx9AUr/YeFpDkpYwEu1RsPe4UXk2+QL7IA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.5",
         "@smithy/credential-provider-imds": "^4.2.7",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.3",
+        "@smithy/smithy-client": "^4.10.4",
         "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
@@ -5836,13 +5843,15 @@
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
       "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/earcut": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
       "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -5905,9 +5914,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
-      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "version": "25.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.5.tgz",
+      "integrity": "sha512-FuLxeLuSVOqHPxSN1fkcD8DLU21gAP7nCKqGRJ/FglbCUBs0NYN6TpHcdmyLeh8C0KwGIaZQJSv+OYG+KZz+Gw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -5940,7 +5949,6 @@
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
       "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -6224,7 +6232,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.26.tgz",
       "integrity": "sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/compiler-core": "3.5.26",
@@ -6385,7 +6392,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6812,9 +6818,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.13.tgz",
-      "integrity": "sha512-WhtvB2NG2wjr04+h77sg3klAIwrgOqnjS49GGudnUPGFFgg7G17y7Qecqp+2Dr5kUDxNRBca0SK7cG8JwzkWDQ==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
+      "integrity": "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -6910,7 +6916,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7029,7 +7034,6 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7052,6 +7056,7 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -7169,7 +7174,6 @@
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "consola": "^3.2.3"
       }
@@ -7257,6 +7261,17 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/commondir": {
@@ -8016,7 +8031,6 @@
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
       "integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=4",
@@ -8161,7 +8175,8 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -8302,7 +8317,6 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8405,7 +8419,8 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -9419,7 +9434,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
       "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -10796,7 +10812,6 @@
       "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.20.2.tgz",
       "integrity": "sha512-DoayekzYjYmGj7A5iI7crBiLRTq1K8U1DLgAR/vGADh1IQfOLagn5Klg1Jn1xxIyN8x0iiFDf3dGd2JWyiKBLA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dxup/nuxt": "^0.2.2",
         "@nuxt/cli": "^3.31.1",
@@ -10909,6 +10924,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11069,7 +11085,6 @@
       "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.102.0.tgz",
       "integrity": "sha512-xMiyHgr2FZsphQ12ZCsXRvSYzmKXCm1ejmyG4GDZIiKOmhyt5iKtWq0klOfFsEQ6jcgbwrUdwcCVYzr1F+h5og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.102.0"
       },
@@ -11331,7 +11346,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11794,7 +11808,6 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
       "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
       "license": "Unlicense",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11898,13 +11911,15 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/qs": {
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
       "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -12181,7 +12196,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
       "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12486,6 +12500,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -12505,6 +12520,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -12521,6 +12537,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -12539,6 +12556,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -14087,6 +14105,7 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
       "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.12.3"
@@ -14121,7 +14140,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -14957,7 +14975,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
       "integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/compiler-sfc": "3.5.26",
@@ -14994,7 +15011,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },


### PR DESCRIPTION
## 自动依赖更新

- 触发时间: 2026-01-10
- 工作流: dependency-update.yml
- Node.js 版本: 20

<details>
<summary>📋 详细更新信息（点击展开）</summary>

#### 更新的文件
- package-lock.json 已更新



#### 安全审计结果
```
正在运行安全审计...

# npm audit report

esbuild  <=0.24.2
Severity: moderate
esbuild enables any website to send any requests to the development server and read the response - https://github.com/advisories/GHSA-67mh-4wv8-2f99
fix available via `npm audit fix --force`
Will install drizzle-kit@0.18.1, which is a breaking change
node_modules/@esbuild-kit/core-utils/node_modules/esbuild
  @esbuild-kit/core-utils  *
  Depends on vulnerable versions of esbuild
  node_modules/@esbuild-kit/core-utils
    @esbuild-kit/esm-loader  *
    Depends on vulnerable versions of @esbuild-kit/core-utils
    node_modules/@esbuild-kit/esm-loader
      drizzle-kit  0.17.5-6b7793f - 0.17.5-e5944eb || 0.18.1-065de38 - 0.18.1-f3800bf || 0.19.0-07024c4 - 1.0.0-beta.1-fd8bfcc
      Depends on vulnerable versions of @esbuild-kit/esm-loader
      node_modules/drizzle-kit

jspdf  <=3.0.4
Severity: critical
jsPDF has Local File Inclusion/Path Traversal vulnerability - https://github.com/advisories/GHSA-f8cm-6447-x5h2
fix available via `npm audit fix --force`
Will install jspdf@4.0.0, which is a breaking change
node_modules/jspdf
  html2pdf.js  <=0.12.1
  Depends on vulnerable versions of jspdf
  node_modules/html2pdf.js

nodemailer  <=7.0.10
Severity: moderate
Nodemailer: Email to an unintended domain can occur due to Interpretation Conflict - https://github.com/advisories/GHSA-mm7p-fcc7-pg87
Nodemailer’s addressparser is vulnerable to DoS caused by recursive calls - https://github.com/advisories/GHSA-rcmh-qjqh-p98v
Nodemailer is vulnerable to DoS through Uncontrolled Recursion - https://github.com/advisories/GHSA-46j5-6fg5-4gv3
fix available via `npm audit fix --force`
Will install nodemailer@7.0.12, which is a breaking change
node_modules/nodemailer

xlsx  *
Severity: high
Prototype Pollution in sheetJS - https://github.com/advisories/GHSA-4r6h-8v6p-xvw6
SheetJS Regular Expression Denial of Service (ReDoS) - https://github.com/advisories/GHSA-5pgg-2g8v-p4x9
No fix available
node_modules/xlsx

8 vulnerabilities (5 moderate, 1 high, 2 critical)

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

--- 审计摘要 ---
总计发现: 8 vulnerabilities
漏洞详情:
esbuild  <=0.24.2
Severity: moderate
esbuild enables any website to send any requests to the development server and read the response - https://github.com/advisories/GHSA-67mh-4wv8-2f99
fix available via `npm audit fix --force`
--
jspdf  <=3.0.4
Severity: critical
jsPDF has Local File Inclusion/Path Traversal vulnerability - https://github.com/advisories/GHSA-f8cm-6447-x5h2
fix available via `npm audit fix --force`
--
```

</details>