### PR TITLE
fix: docker启动命令从 npm run dev 改为 npm start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY package*.json ./
 COPY scripts ./scripts
 
 # 安装所有依赖（含开发依赖）
-RUN npm ci
+RUN npm install
 
 # 复制源代码并构建应用
 COPY . .
@@ -35,4 +35,4 @@ ENV NODE_ENV=production \
 
 # 暴露端口并设置启动命令
 EXPOSE $PORT
-CMD ["sh", "-c", "npm run deploy && npm run dev"]
+CMD ["sh", "-c", "npm run setup && npm start"]


### PR DESCRIPTION
fix: docker启动命令从 npm run dev 改为 npm start
注意：此为尝试性更改，未测试