### PR TITLE
style(admin): 统一用户角色常量命名规范，修复角色权限显示问题

### DIFF
--- a/app/components/Admin/UserManager.vue
+++ b/app/components/Admin/UserManager.vue
@@ -164,17 +164,17 @@
                 </td>
                 <td class="px-6 py-5">
                   <span
-                    v-if="user.role === 'super_admin'"
+                    v-if="user.role === 'SUPER_ADMIN'"
                     class="px-2 py-0.5 bg-orange-500/10 text-orange-400 text-[10px] font-black rounded border border-orange-500/20 uppercase tracking-widest"
                     >超级管理员</span
                   >
                   <span
-                    v-else-if="user.role === 'admin'"
+                    v-else-if="user.role === 'ADMIN'"
                     class="px-2 py-0.5 bg-blue-500/10 text-blue-400 text-[10px] font-black rounded border border-blue-500/20 uppercase tracking-widest"
                     >管理员</span
                   >
                   <span
-                    v-else-if="user.role === 'song_admin'"
+                    v-else-if="user.role === 'SONG_ADMIN'"
                     class="px-2 py-0.5 bg-purple-500/10 text-purple-400 text-[10px] font-black rounded border border-purple-500/20 uppercase tracking-widest"
                     >歌曲管理</span
                   >
@@ -336,17 +336,17 @@
                 </p>
                 <div>
                   <span
-                    v-if="user.role === 'super_admin'"
+                    v-if="user.role === 'SUPER_ADMIN'"
                     class="px-2 py-0.5 bg-orange-500/10 text-orange-400 text-[10px] font-black rounded border border-orange-500/20 uppercase tracking-widest"
                     >超级管理员</span
                   >
                   <span
-                    v-else-if="user.role === 'admin'"
+                    v-else-if="user.role === 'ADMIN'"
                     class="px-2 py-0.5 bg-blue-500/10 text-blue-400 text-[10px] font-black rounded border border-blue-500/20 uppercase tracking-widest"
                     >管理员</span
                   >
                   <span
-                    v-else-if="user.role === 'song_admin'"
+                    v-else-if="user.role === 'SONG_ADMIN'"
                     class="px-2 py-0.5 bg-purple-500/10 text-purple-400 text-[10px] font-black rounded border border-purple-500/20 uppercase tracking-widest"
                     >歌曲管理</span
                   >


### PR DESCRIPTION
- 将 super_admin 角色标识符修改为 SUPER_ADMIN
- 将 admin 角色标识符修改为 ADMIN
- 将 song_admin 角色标识符修改为 SONG_ADMIN
- 保持角色显示文本不变，仅调整后端标识符格式
- 确保所有角色判断逻辑的一致性
- 提升代码可读性和维护性