### PR TITLE
fix(database): 修复数据库序列重置逻辑

### DIFF
--- a/scripts/clear-database.js
+++ b/scripts/clear-database.js
@@ -23,6 +23,29 @@ import {
 } from '../app/drizzle/db.ts'
 import bcrypt from 'bcrypt'
 
+function getFirstRow(result) {
+  return result?.rows?.[0] ?? result?.[0]
+}
+
+function quoteIdentifierPart(value) {
+  const normalized =
+    value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1).replace(/""/g, '"') : value
+
+  return `"${normalized.replace(/"/g, '""')}"`
+}
+
+function toQualifiedIdentifier(value) {
+  return sql.raw(value.split('.').map(quoteIdentifierPart).join('.'))
+}
+
+function toPgRelationName(value) {
+  return value.split('.').map(quoteIdentifierPart).join('.')
+}
+
+function toRegclass(value) {
+  return sql.raw(`'${value.replace(/'/g, "''")}'::regclass`)
+}
+
 // 重置所有表的自增序列
 async function resetAutoIncrementSequences() {
   const tables = [
@@ -44,23 +67,22 @@ async function resetAutoIncrementSequences() {
 
   for (const table of tables) {
     try {
-      // 获取表的最大ID
-      const maxIdResult = await db.execute(sql`SELECT MAX(id) as max_id FROM ${sql.identifier(table)}`)
-      const maxId = Number(maxIdResult.rows?.[0]?.max_id || maxIdResult[0]?.max_id || 0)
-
-      // PostgreSQL 获取序列名称并重置
-      const sequenceNameResult = await db.execute(
-        sql`SELECT pg_get_serial_sequence(${table}, 'id') as sequence_name`
+      const maxIdResult = await db.execute(
+        sql`SELECT MAX(id) as max_id FROM ${toQualifiedIdentifier(table)}`
       )
-      const sequenceName =
-        sequenceNameResult.rows?.[0]?.sequence_name || sequenceNameResult[0]?.sequence_name
+      const maxId = Number(getFirstRow(maxIdResult)?.max_id || 0)
+
+      const sequenceNameResult = await db.execute(
+        sql`SELECT pg_get_serial_sequence(${toPgRelationName(table)}, 'id') as sequence_name`
+      )
+      const sequenceName = getFirstRow(sequenceNameResult)?.sequence_name
 
       if (sequenceName) {
         if (maxId === 0) {
-          await db.execute(sql`ALTER SEQUENCE ${sql.identifier(sequenceName)} RESTART WITH 1`)
+          await db.execute(sql`ALTER SEQUENCE ${toQualifiedIdentifier(sequenceName)} RESTART WITH 1`)
         } else {
           const newSequenceValue = maxId
-          await db.execute(sql`SELECT setval(${sequenceName}, ${newSequenceValue})`)
+          await db.execute(sql`SELECT setval(${toRegclass(sequenceName)}, ${newSequenceValue})`)
         }
       } else {
         console.warn(`未找到表 ${table} 的序列`)
@@ -123,14 +145,13 @@ async function main() {
     // 调整User表的自增序列，确保下一个用户从admin.id + 1开始
     try {
       const sequenceNameResult = await db.execute(
-        sql`SELECT pg_get_serial_sequence('User', 'id') as sequence_name`
+        sql`SELECT pg_get_serial_sequence(${toPgRelationName('User')}, 'id') as sequence_name`
       )
-      const sequenceName =
-        sequenceNameResult.rows?.[0]?.sequence_name || sequenceNameResult[0]?.sequence_name
+      const sequenceName = getFirstRow(sequenceNameResult)?.sequence_name
 
       if (sequenceName) {
         const nextId = admin.id
-        await db.execute(sql`SELECT setval(${sequenceName}, ${nextId})`)
+        await db.execute(sql`SELECT setval(${toRegclass(sequenceName)}, ${nextId})`)
       }
     } catch (error) {
       console.warn(`调整User表序列失败: ${error.message}`)

--- a/server/api/admin/database/reset.post.ts
+++ b/server/api/admin/database/reset.post.ts
@@ -25,6 +25,29 @@ import {
 } from '~/drizzle/schema'
 import { ne, sql } from 'drizzle-orm'
 
+function getFirstRow<T>(result: any): T | undefined {
+  return result?.rows?.[0] ?? result?.[0]
+}
+
+function quoteIdentifierPart(value: string) {
+  const normalized =
+    value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1).replace(/""/g, '"') : value
+
+  return `"${normalized.replace(/"/g, '""')}"`
+}
+
+function toQualifiedIdentifier(value: string) {
+  return sql.raw(value.split('.').map(quoteIdentifierPart).join('.'))
+}
+
+function toPgRelationName(value: string) {
+  return value.split('.').map(quoteIdentifierPart).join('.')
+}
+
+function toRegclass(value: string) {
+  return sql.raw(`'${value.replace(/'/g, "''")}'::regclass`)
+}
+
 // 重置所有表的自增序列
 async function resetAutoIncrementSequences() {
   const tables = [
@@ -51,24 +74,22 @@ async function resetAutoIncrementSequences() {
     try {
       // 获取表的最大ID
       const maxIdResult = await db.execute(
-        sql`SELECT MAX(id) as max_id FROM ${sql.identifier(table.dbName)}`
+        sql`SELECT MAX(id) as max_id FROM ${toQualifiedIdentifier(table.dbName)}`
       )
-      const maxId = Number((maxIdResult as any).rows?.[0]?.max_id || (maxIdResult as any)[0]?.max_id || 0)
+      const maxId = Number(getFirstRow<{ max_id: number | string | null }>(maxIdResult)?.max_id || 0)
 
       // 获取序列名称
       const sequenceNameResult = await db.execute(
-        sql`SELECT pg_get_serial_sequence(${table.dbName}, 'id') as sequence_name`
+        sql`SELECT pg_get_serial_sequence(${toPgRelationName(table.dbName)}, 'id') as sequence_name`
       )
-      const sequenceName = (sequenceNameResult as any).rows?.[0]?.sequence_name || (sequenceNameResult as any)[0]?.sequence_name
+      const sequenceName = getFirstRow<{ sequence_name: string | null }>(sequenceNameResult)?.sequence_name
 
       if (sequenceName) {
         if (maxId === 0) {
-          // 表为空，重置序列到 1
-          await db.execute(sql`ALTER SEQUENCE ${sql.identifier(sequenceName)} RESTART WITH 1`)
+          await db.execute(sql`ALTER SEQUENCE ${toQualifiedIdentifier(sequenceName)} RESTART WITH 1`)
         } else {
-          // 表不为空（例如保留了管理员用户），重置序列到最大ID
           const newSequenceValue = maxId
-          await db.execute(sql`SELECT setval(${sequenceName}, ${newSequenceValue})`)
+          await db.execute(sql`SELECT setval(${toRegclass(sequenceName)}, ${newSequenceValue})`)
         }
         results.push({ table: table.name, success: true })
       } else {

--- a/server/api/admin/fix-sequence.post.ts
+++ b/server/api/admin/fix-sequence.post.ts
@@ -1,18 +1,43 @@
 import { db } from '~/drizzle/db'
 import { sql } from 'drizzle-orm'
 
+function getFirstRow<T>(result: any): T | undefined {
+  return result?.rows?.[0] ?? result?.[0]
+}
+
+function quoteIdentifierPart(value: string) {
+  const normalized =
+    value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1).replace(/""/g, '"') : value
+
+  return `"${normalized.replace(/"/g, '""')}"`
+}
+
+function toQualifiedIdentifier(value: string) {
+  return sql.raw(value.split('.').map(quoteIdentifierPart).join('.'))
+}
+
+function toPgRelationName(value: string) {
+  return value.split('.').map(quoteIdentifierPart).join('.')
+}
+
+function toRegclass(value: string) {
+  return sql.raw(`'${value.replace(/'/g, "''")}'::regclass`)
+}
+
 // 修复单个表的序列
 async function fixTableSequence(table: string, dbTableName: string) {
   try {
     // 获取表的最大ID
-    const maxIdResult = await db.execute(sql`SELECT MAX(id) as max_id FROM ${sql.identifier(dbTableName)}`)
-    const maxId = Number((maxIdResult as any).rows?.[0]?.max_id || (maxIdResult as any)[0]?.max_id || 0)
+    const maxIdResult = await db.execute(
+      sql`SELECT MAX(id) as max_id FROM ${toQualifiedIdentifier(dbTableName)}`
+    )
+    const maxId = Number(getFirstRow<{ max_id: number | string | null }>(maxIdResult)?.max_id || 0)
 
     // 获取序列名称
     const sequenceNameResult = await db.execute(
-      sql`SELECT pg_get_serial_sequence(${dbTableName}, 'id') as sequence_name`
+      sql`SELECT pg_get_serial_sequence(${toPgRelationName(dbTableName)}, 'id') as sequence_name`
     )
-    const sequenceName = (sequenceNameResult as any).rows?.[0]?.sequence_name || (sequenceNameResult as any)[0]?.sequence_name
+    const sequenceName = getFirstRow<{ sequence_name: string | null }>(sequenceNameResult)?.sequence_name
 
     if (!sequenceName) {
       return {
@@ -23,8 +48,7 @@ async function fixTableSequence(table: string, dbTableName: string) {
     }
 
     if (maxId === 0) {
-      // 表为空，重置序列为 1
-      await db.execute(sql`ALTER SEQUENCE ${sql.identifier(sequenceName)} RESTART WITH 1`)
+      await db.execute(sql`ALTER SEQUENCE ${toQualifiedIdentifier(sequenceName)} RESTART WITH 1`)
       return {
         success: true,
         table: table,
@@ -38,29 +62,14 @@ async function fixTableSequence(table: string, dbTableName: string) {
       }
     }
 
-    // 获取当前序列值
-    const currentSeqResult = await db.execute(sql`SELECT last_value FROM ${sql.identifier(sequenceName)}`)
-    const currentSeqValue = Number((currentSeqResult as any).rows?.[0]?.last_value || (currentSeqResult as any)[0]?.last_value || 0)
-
-    // 重置序列值到最大ID
+    const currentSeqResult = await db.execute(
+      sql`SELECT last_value FROM ${toQualifiedIdentifier(sequenceName)}`
+    )
+    const currentSeqValue = Number(
+      getFirstRow<{ last_value: number | string }>(currentSeqResult)?.last_value || 0
+    )
     const newSequenceValue = maxId
-
-    // 检查序列是否已经正确
-    if (currentSeqValue >= newSequenceValue && currentSeqValue > 0) {
-      return {
-        success: true,
-        table: table,
-        message: `表 ${table} 序列值已正确，无需修复`,
-        data: {
-          table: table,
-          maxId: maxId,
-          currentSequenceValue: currentSeqValue,
-          alreadyCorrect: true
-        }
-      }
-    }
-
-    await db.execute(sql`SELECT setval(${sequenceName}, ${newSequenceValue})`)
+    await db.execute(sql`SELECT setval(${toRegclass(sequenceName)}, ${newSequenceValue})`)
 
     return {
       success: true,


### PR DESCRIPTION
- 在clear-database.js中引入drizzle-orm的sql模块以支持原生SQL查询
- 修改表序列重置逻辑，先获取表最大ID再决定如何重置序列
- 使用pg_get_serial_sequence函数动态获取PostgreSQL序列名
- 为空表重置序列到1，非空表重置序列到最大ID+1
- 优化User表序列调整逻辑，确保管理员用户后的新用户ID连续
- 更新fix-sequence.post.ts处理空表情况的序列重置
- 改进database/reset.post.ts中的序列重置策略以保持ID连续性