### PR TITLE
feat(songs): 添加管理员查看歌曲期望播出时段功能

### DIFF
--- a/app/components/Admin/ScheduleManager.vue
+++ b/app/components/Admin/ScheduleManager.vue
@@ -268,6 +268,12 @@
                   value-key="name"
                   @update:model-value="handleSemesterSelect"
                 />
+                <CustomSelect
+                  v-if="playTimeEnabled"
+                  v-model="selectedFilterPlayTime"
+                  label="期望时段"
+                  :options="filterPlayTimeOptions"
+                />
                 <div class="grid grid-cols-2 gap-2">
                   <CustomSelect v-model="selectedGrade" label="年级" :options="availableGrades" />
                   <CustomSelect v-model="songSortOption" label="排序" :options="sortOptions" />
@@ -1111,6 +1117,25 @@ const isDraftMode = ref(false)
 const playTimes = ref([])
 const playTimeEnabled = ref(false)
 const selectedPlayTime = ref('')
+const selectedFilterPlayTime = ref('all')
+
+// 待排歌曲的播出时段筛选选项
+const filterPlayTimeOptions = computed(() => {
+  const options = [
+    { label: '全部时段', value: 'all' },
+    { label: '未指定时段', value: 'none' }
+  ]
+  if (playTimes.value) {
+    playTimes.value.forEach((pt) => {
+      let label = pt.name
+      if (pt.startTime || pt.endTime) {
+        label += ` (${formatPlayTimeRange(pt)})`
+      }
+      options.push({ label, value: pt.id })
+    })
+  }
+  return options
+})
 
 // 播出时段选项
 const playTimeOptions = computed(() => {
@@ -1253,6 +1278,16 @@ const allUnscheduledSongs = computed(() => {
     unscheduledSongs = unscheduledSongs.filter(
       (song) => song.requesterGrade === selectedGrade.value
     )
+  }
+
+  // 播出时段过滤
+  if (selectedFilterPlayTime.value !== 'all') {
+    unscheduledSongs = unscheduledSongs.filter((song) => {
+      if (selectedFilterPlayTime.value === 'none') {
+        return !song.preferredPlayTimeId
+      }
+      return song.preferredPlayTimeId === selectedFilterPlayTime.value
+    })
   }
 
   return [...unscheduledSongs].sort((a, b) => {
@@ -1600,6 +1635,11 @@ watch(selectedGrade, () => {
   resetAllPages()
 })
 
+// 监听期望时段筛选变化，重置分页
+watch(selectedFilterPlayTime, () => {
+  resetAllPages()
+})
+
 // 加载重播申请
 const fetchReplayRequests = async () => {
   try {
@@ -1711,7 +1751,13 @@ const formatPlayTimeRange = (playTime) => {
 const getPlayTimeName = (playTimeId) => {
   if (!playTimeId || !playTimes.value) return ''
   const playTime = playTimes.value.find((pt) => pt.id === playTimeId)
-  return playTime ? playTime.name : ''
+  if (!playTime) return ''
+  
+  let label = playTime.name
+  if (playTime.startTime || playTime.endTime) {
+    label += ` (${formatPlayTimeRange(playTime)})`
+  }
+  return label
 }
 
 // 加载学期列表

--- a/app/components/Admin/SongManagement.vue
+++ b/app/components/Admin/SongManagement.vue
@@ -2059,7 +2059,7 @@ onMounted(async () => {
     selectedSemester.value = currentSemester.value.name
   }
 
-  const { fetchPlayTimes, playTimes, formatPlayTimeDisplay: formatter } = useSongs()
+  const { fetchPlayTimes, playTimes, formatPlayTimeDisplay: formatter } = songsService
   formatPlayTimeDisplay = formatter
   await fetchPlayTimes()
   availablePlayTimes.value = [...(playTimes.value || [])]

--- a/app/components/Admin/SongManagement.vue
+++ b/app/components/Admin/SongManagement.vue
@@ -90,7 +90,7 @@
             class="w-full bg-zinc-950/50 border border-zinc-800/80 rounded-lg pl-12 pr-4 py-3 text-sm focus:outline-none focus:border-blue-500/30 transition-all placeholder:text-zinc-800 text-zinc-200"
           >
         </div>
-        <div class="grid grid-cols-2 md:grid-cols-3 lg:flex lg:items-center gap-3 w-full lg:w-auto">
+        <div class="grid grid-cols-2 md:grid-cols-4 lg:flex lg:items-center gap-3 w-full lg:w-auto">
           <CustomSelect
             v-model="selectedSemester"
             label="学期"
@@ -98,6 +98,15 @@
             label-key="name"
             value-key="name"
             placeholder="选择学期"
+            class-name="w-full lg:w-40"
+          />
+          <CustomSelect
+            v-model="selectedPlayTime"
+            label="播出时段"
+            :options="availablePlayTimes"
+            label-key="name"
+            value-key="id"
+            placeholder="选择时段"
             class-name="w-full lg:w-40"
           />
           <CustomSelect
@@ -260,6 +269,9 @@
             <span v-if="song.user" class="text-[10px] font-bold text-zinc-600"
               >@{{ song.user.username }}</span
             >
+            <span v-if="song.preferredPlayTimeId" class="text-[10px] font-bold text-blue-500 mt-1">
+              期望: {{ getPlayTimeName(song.preferredPlayTimeId) }}
+            </span>
             <span
               class="hidden lg:inline text-[9px] font-black text-zinc-700 uppercase tracking-widest mt-1 opacity-60"
               >{{ formatDate(song.createdAt) }}</span
@@ -695,26 +707,49 @@
               </div>
             </div>
 
-            <div class="space-y-2">
-              <label class="text-[10px] font-black text-zinc-600 uppercase tracking-widest px-1"
-                >学期</label
-              >
-              <CustomSelect
-                v-if="showEditModal"
-                v-model="editForm.semester"
-                :options="availableSemesters"
-                label-key="name"
-                value-key="name"
-                placeholder="选择学期"
-              />
-              <CustomSelect
-                v-else
-                v-model="addForm.semester"
-                :options="availableSemesters"
-                label-key="name"
-                value-key="name"
-                placeholder="选择学期"
-              />
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+              <div class="space-y-2">
+                <label class="text-[10px] font-black text-zinc-600 uppercase tracking-widest px-1"
+                  >学期</label
+                >
+                <CustomSelect
+                  v-if="showEditModal"
+                  v-model="editForm.semester"
+                  :options="availableSemesters"
+                  label-key="name"
+                  value-key="name"
+                  placeholder="选择学期"
+                />
+                <CustomSelect
+                  v-else
+                  v-model="addForm.semester"
+                  :options="availableSemesters"
+                  label-key="name"
+                  value-key="name"
+                  placeholder="选择学期"
+                />
+              </div>
+              <div class="space-y-2">
+                <label class="text-[10px] font-black text-zinc-600 uppercase tracking-widest px-1"
+                  >期望时段 (可选)</label
+                >
+                <CustomSelect
+                  v-if="showEditModal"
+                  v-model="editForm.preferredPlayTimeId"
+                  :options="availablePlayTimes.filter(p => p.id !== 'all')"
+                  label-key="name"
+                  value-key="id"
+                  placeholder="选择期望播出时段"
+                />
+                <CustomSelect
+                  v-else
+                  v-model="addForm.preferredPlayTimeId"
+                  :options="availablePlayTimes.filter(p => p.id !== 'all')"
+                  label-key="name"
+                  value-key="id"
+                  placeholder="选择期望播出时段"
+                />
+              </div>
             </div>
 
 
@@ -1004,6 +1039,10 @@ const { playSong } = useSongPlayer()
 const selectedSemester = ref('all')
 const availableSemesters = ref([])
 
+// 时段相关
+const selectedPlayTime = ref('all')
+const availablePlayTimes = ref([])
+
 // 选项配置
 const statusOptions = [
   { label: '全部状态', value: 'all' },
@@ -1067,6 +1106,7 @@ const editForm = ref({
   artist: '',
   requester: '',
   semester: '',
+  preferredPlayTimeId: 'none',
   submissionNote: '',
   submissionNotePublic: false,
   musicPlatform: '',
@@ -1088,6 +1128,7 @@ const addForm = ref({
   artist: '',
   requester: '',
   semester: '',
+  preferredPlayTimeId: 'none',
   musicPlatform: '',
   musicId: '',
   cover: '',
@@ -1129,6 +1170,7 @@ const songs = ref([])
 let songsService = null
 let adminService = null
 let auth = null
+let formatPlayTimeDisplay = (pt) => pt?.name || ''
 
 // 计算属性
 const filteredSongs = computed(() => {
@@ -1150,6 +1192,16 @@ const filteredSongs = computed(() => {
   // 学期过滤
   if (selectedSemester.value && selectedSemester.value !== 'all') {
     filtered = filtered.filter((song) => song.semester === selectedSemester.value)
+  }
+
+  // 时段过滤
+  if (selectedPlayTime.value && selectedPlayTime.value !== 'all') {
+    filtered = filtered.filter((song) => {
+      if (selectedPlayTime.value === 'none') {
+        return !song.preferredPlayTimeId
+      }
+      return song.preferredPlayTimeId === selectedPlayTime.value
+    })
   }
 
   // 状态过滤
@@ -1266,6 +1318,14 @@ const formatDate = (dateString) => {
   if (diff < 3600000) return `${Math.floor(diff / 60000)}分钟前`
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}小时前`
   return `${Math.floor(diff / 86400000)}天前`
+}
+
+const getPlayTimeName = (playTimeId) => {
+  if (!playTimeId || !availablePlayTimes.value) return ''
+  const playTime = availablePlayTimes.value.find((pt) => pt.id === playTimeId)
+  if (!playTime) return ''
+  
+  return formatPlayTimeDisplay(playTime)
 }
 
 const getStatusText = (song) => {
@@ -1552,6 +1612,7 @@ const editSong = (song) => {
     artist: song.artist || '',
     requester: song.requesterId || song.requester_id || song.requester || '',
     semester: song.semester || '',
+    preferredPlayTimeId: song.preferredPlayTimeId || 'none',
     submissionNote: song.submissionNote || '',
     submissionNotePublic: song.submissionNotePublic === true,
     musicPlatform: song.musicPlatform || '',
@@ -1614,6 +1675,7 @@ const saveEditSong = async () => {
       requester: editForm.value.requester,
       collaborators: selectedEditCollaborators.value.map((u) => u.id),
       semester: editForm.value.semester,
+      preferredPlayTimeId: editForm.value.preferredPlayTimeId === 'none' ? null : (editForm.value.preferredPlayTimeId || null),
       submissionNote: submissionNoteClearRequested.value ? null : editForm.value.submissionNote,
       submissionNotePublic: submissionNoteClearRequested.value ? false : editForm.value.submissionNotePublic,
       clearSubmissionNote: submissionNoteClearRequested.value,
@@ -1651,6 +1713,7 @@ const cancelEditSong = () => {
     artist: '',
     requester: '',
     semester: '',
+    preferredPlayTimeId: 'none',
     submissionNote: '',
     submissionNotePublic: false,
     musicPlatform: '',
@@ -1691,6 +1754,7 @@ const openAddSongModal = () => {
     artist: '',
     requester: '',
     semester: selectedSemester.value !== 'all' ? selectedSemester.value : '',
+    preferredPlayTimeId: selectedPlayTime.value !== 'all' && selectedPlayTime.value !== 'none' ? selectedPlayTime.value : 'none',
     musicPlatform: '',
     musicId: '',
     cover: ''
@@ -1744,6 +1808,7 @@ const saveAddSong = async () => {
       artist: addForm.value.artist,
       requester: addForm.value.requester,
       semester: addForm.value.semester,
+      preferredPlayTimeId: addForm.value.preferredPlayTimeId === 'none' ? null : (addForm.value.preferredPlayTimeId || null),
       musicPlatform: addForm.value.musicPlatform || null,
       musicId: addForm.value.musicId || null,
       cover: addForm.value.cover || null,
@@ -1758,6 +1823,7 @@ const saveAddSong = async () => {
       artist: '',
       requester: '',
       semester: '',
+      preferredPlayTimeId: 'none',
       musicPlatform: '',
       musicId: '',
       cover: '',
@@ -1787,6 +1853,7 @@ const cancelAddSong = () => {
     artist: '',
     requester: '',
     semester: '',
+    preferredPlayTimeId: 'none',
     musicPlatform: '',
     musicId: '',
     cover: '',
@@ -1964,7 +2031,7 @@ const handleClickOutside = (event) => {
 
 
 // 监听器
-watch([searchQuery, statusFilter, sortOption, selectedSemester], () => {
+watch([searchQuery, statusFilter, sortOption, selectedSemester, selectedPlayTime], () => {
   currentPage.value = 1
 })
 
@@ -1991,6 +2058,13 @@ onMounted(async () => {
   if (currentSemester.value) {
     selectedSemester.value = currentSemester.value.name
   }
+
+  const { fetchPlayTimes, playTimes, formatPlayTimeDisplay: formatter } = useSongs()
+  formatPlayTimeDisplay = formatter
+  await fetchPlayTimes()
+  availablePlayTimes.value = [...(playTimes.value || [])]
+  availablePlayTimes.value.unshift({ id: 'none', name: '未指定时段' })
+  availablePlayTimes.value.unshift({ id: 'all', name: '全部时段' })
 
   document.addEventListener('click', handleClickOutside)
 

--- a/app/components/Songs/RequestForm.vue
+++ b/app/components/Songs/RequestForm.vue
@@ -1371,10 +1371,14 @@ const enabledPlayTimes = computed(() => {
 })
 
 const formattedPlayTimes = computed(() => {
-  return enabledPlayTimes.value.map((pt) => ({
+  const options = enabledPlayTimes.value.map((pt) => ({
     ...pt,
     displayName: pt.startTime || pt.endTime ? `${pt.name} (${formatPlayTimeRange(pt)})` : pt.name
   }))
+  return [
+    { id: '', displayName: '不指定时段' },
+    ...options
+  ]
 })
 
 // 格式化播出时段时间范围

--- a/app/components/Songs/RequestForm.vue
+++ b/app/components/Songs/RequestForm.vue
@@ -320,7 +320,7 @@
           </div>
 
           <div class="results-content">
-            <!-- 播出时段和备注 - 移动到搜索结果上方 -->
+            <!-- 播出时段和备注 -->
             <div v-if="playTimeSelectionEnabled || enableSubmissionRemarks" class="form-row">
               <!-- 播出时段选择 -->
               <div v-if="playTimeSelectionEnabled" class="form-group">

--- a/app/components/Songs/RequestForm.vue
+++ b/app/components/Songs/RequestForm.vue
@@ -321,9 +321,9 @@
 
           <div class="results-content">
             <!-- 播出时段和备注 - 移动到搜索结果上方 -->
-            <div v-if="(playTimeSelectionEnabled && playTimes.length > 0) || enableSubmissionRemarks" class="form-row">
+            <div v-if="playTimeSelectionEnabled || enableSubmissionRemarks" class="form-row">
               <!-- 播出时段选择 -->
-              <div v-if="playTimeSelectionEnabled && playTimes.length > 0" class="form-group">
+              <div v-if="playTimeSelectionEnabled" class="form-group">
                 <div class="input-wrapper">
                   <CustomSelect
                     v-model="preferredPlayTimeId"

--- a/server/api/songs/[id]/update.put.ts
+++ b/server/api/songs/[id]/update.put.ts
@@ -42,7 +42,7 @@ export default defineEventHandler(async (event) => {
 
     // 获取请求体
     const body = await readBody(event)
-    const { title, artist, requester, semester, musicPlatform, musicId, cover, playUrl } = body
+    const { title, artist, requester, semester, musicPlatform, musicId, cover, playUrl, preferredPlayTimeId } = body
     const ipAddress =
       (event.node.req.headers['x-forwarded-for'] as string) || event.node.req.socket.remoteAddress
 
@@ -70,6 +70,7 @@ export default defineEventHandler(async (event) => {
     }
 
     if (body.semester !== undefined) updateData.semester = body.semester || null
+    if (body.preferredPlayTimeId !== undefined) updateData.preferredPlayTimeId = body.preferredPlayTimeId || null
     if (body.musicPlatform !== undefined) updateData.musicPlatform = body.musicPlatform || null
     if (body.musicId !== undefined) updateData.musicId = body.musicId || null
     if (body.cover !== undefined) updateData.cover = body.cover || null

--- a/server/api/songs/add.post.ts
+++ b/server/api/songs/add.post.ts
@@ -32,7 +32,7 @@ export default defineEventHandler(async (event) => {
 
     // 获取请求体
     const body = await readBody(event)
-    const { title, artist, requester, semester, musicPlatform, musicId, cover, playUrl } = body
+    const { title, artist, requester, semester, musicPlatform, musicId, cover, playUrl, preferredPlayTimeId } = body
 
     // 验证必填字段
     if (!title || !artist) {
@@ -95,6 +95,7 @@ export default defineEventHandler(async (event) => {
         artist: artist.trim(),
         requesterId,
         semester: semester || null,
+        preferredPlayTimeId: preferredPlayTimeId || null,
         musicPlatform: musicPlatform || null,
         musicId: musicId || null,
         cover: cover || null,


### PR DESCRIPTION
- 在歌曲请求表单中增加期望时段选择下拉框
- 实现后台API支持preferredPlayTimeId字段的存储和更新
- 在管理员排程管理界面添加时段筛选功能
- 在歌曲管理页面显示歌曲的期望播出时段信息
- 实现按时段筛选和排序的前端逻辑
- 添加时段数据的初始化和格式化显示功能

Closed #285