### PR TITLE
feat(auth): 添加密码重置功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,9 +662,11 @@ VoiceHub/
 │   │   │   └── error.vue      # 认证错误页面
 │   │   ├── change-password.vue # 修改密码页面
 │   │   ├── dashboard.vue       # 用户仪表盘
+│   │   ├── forgot-password.vue # 找回密码页面
 │   │   ├── index.vue           # 首页
 │   │   ├── login.vue           # 登录页面
 │   │   ├── notification-settings.vue # 通知设置页面
+│   │   ├── reset-password.vue  # 重置密码页面
 │   │   └── year-review.vue     # 年度回顾页面
 │   ├── plugins/               # Nuxt插件
 │   │   ├── auth.client.ts      # 客户端认证插件
@@ -825,10 +827,12 @@ VoiceHub/
 │   │   │   │   └── index.get.ts      # OAuth授权跳转
 │   │   │   ├── bind.post.ts          # 绑定社交账号
 │   │   │   ├── change-password.post.ts # 修改密码
+│   │   │   ├── forgot-password.post.ts # 找回密码
 │   │   │   ├── identities.get.ts     # 获取已绑定身份列表
 │   │   │   ├── login.post.ts        # 用户登录
 │   │   │   ├── logout.post.ts       # 用户登出
 │   │   │   ├── oauth-register.post.ts # OAuth用户注册
+│   │   │   ├── reset-password.post.ts # 重置密码
 │   │   │   ├── set-initial-password.post.ts # 设置初始密码
 │   │   │   ├── unbind.post.ts        # 解绑社交账号
 │   │   │   └── verify.get.ts        # 验证Token并获取用户信息

--- a/app/components/Auth/LoginForm.vue
+++ b/app/components/Auth/LoginForm.vue
@@ -96,7 +96,7 @@
       <div class="form-group">
         <div class="flex justify-between items-center w-full mb-2">
           <label for="password" style="margin-bottom: 0;">{{ showCreateMode ? '设置密码' : '密码' }}</label>
-          <NuxtLink v-if="!showCreateMode && !isBindMode" to="/forgot-password" class="text-xs text-[var(--primary)] hover:underline" style="line-height: 1;">
+          <NuxtLink v-if="!showCreateMode && !isBindMode" to="/forgot-password" class="text-xs text-[var(--primary)] hover:opacity-80 transition-opacity" style="line-height: 1;">
             忘记密码？
           </NuxtLink>
         </div>

--- a/app/components/Auth/LoginForm.vue
+++ b/app/components/Auth/LoginForm.vue
@@ -94,8 +94,11 @@
 
       <!-- 密码字段 -->
       <div class="form-group">
-        <label for="password">
-          {{ showCreateMode ? '设置密码' : '密码' }}
+        <label for="password" class="flex justify-between items-center w-full">
+          <span>{{ showCreateMode ? '设置密码' : '密码' }}</span>
+          <NuxtLink v-if="!showCreateMode && !isBindMode" to="/forgot-password" class="text-xs text-[var(--primary)] hover:underline">
+            忘记密码？
+          </NuxtLink>
         </label>
         <div class="input-wrapper">
           <svg

--- a/app/components/Auth/LoginForm.vue
+++ b/app/components/Auth/LoginForm.vue
@@ -94,12 +94,12 @@
 
       <!-- 密码字段 -->
       <div class="form-group">
-        <label for="password" class="flex justify-between items-center w-full">
-          <span>{{ showCreateMode ? '设置密码' : '密码' }}</span>
-          <NuxtLink v-if="!showCreateMode && !isBindMode" to="/forgot-password" class="text-xs text-[var(--primary)] hover:underline">
+        <div class="flex justify-between items-center w-full mb-2">
+          <label for="password" style="margin-bottom: 0;">{{ showCreateMode ? '设置密码' : '密码' }}</label>
+          <NuxtLink v-if="!showCreateMode && !isBindMode" to="/forgot-password" class="text-xs text-[var(--primary)] hover:underline" style="line-height: 1;">
             忘记密码？
           </NuxtLink>
-        </label>
+        </div>
         <div class="input-wrapper">
           <svg
             class="input-icon"

--- a/app/components/Auth/LoginForm.vue
+++ b/app/components/Auth/LoginForm.vue
@@ -297,6 +297,7 @@ import { getProviderDisplayName } from '~/utils/oauth'
 import { validateOAuthRegisterCredentials } from '~/utils/oauth-register'
 import { startAuthentication, browserSupportsWebAuthn } from '@simplewebauthn/browser'
 import { Fingerprint } from 'lucide-vue-next'
+import { usePasswordStrength } from '~/composables/usePasswordStrength'
 
 const { allowOAuthRegistration, fetchSiteConfig } = useSiteConfig()
 
@@ -330,49 +331,7 @@ const tempToken2FA = ref('')
 const maskedEmail2FA = ref('')
 const showCreateMode = ref(false)
 
-const passwordStrength = computed(() => {
-  if (!password.value) return { width: '0%', colorClass: '', textColorClass: '', text: '' }
-
-  let score = 0
-  const value = password.value
-  if (value.length >= 8) score++
-  if (/[a-z]/.test(value)) score++
-  if (/[A-Z]/.test(value)) score++
-  if (/[0-9]/.test(value)) score++
-  if (/[^A-Za-z0-9]/.test(value)) score++
-
-  const scorePercentage = (score / 5) * 100
-
-  if (score < 3) {
-    return {
-      width: `${scorePercentage || 10}%`,
-      colorClass: 'bg-rose-500',
-      textColorClass: 'text-rose-500',
-      text: '弱'
-    }
-  } else if (score < 4) {
-    return {
-      width: `${scorePercentage}%`,
-      colorClass: 'bg-amber-500',
-      textColorClass: 'text-amber-500',
-      text: '中等'
-    }
-  } else if (score < 5) {
-    return {
-      width: `${scorePercentage}%`,
-      colorClass: 'bg-blue-500',
-      textColorClass: 'text-blue-500',
-      text: '强'
-    }
-  } else {
-    return {
-      width: '100%',
-      colorClass: 'bg-emerald-500',
-      textColorClass: 'text-emerald-500',
-      text: '极强'
-    }
-  }
-})
+const passwordStrength = usePasswordStrength(password)
 
 const auth = useAuth()
 

--- a/app/components/Auth/LoginForm.vue
+++ b/app/components/Auth/LoginForm.vue
@@ -96,7 +96,7 @@
       <div class="form-group">
         <div class="flex justify-between items-center w-full mb-2">
           <label for="password" style="margin-bottom: 0;">{{ showCreateMode ? '设置密码' : '密码' }}</label>
-          <NuxtLink v-if="!showCreateMode && !isBindMode" to="/forgot-password" class="text-xs text-[var(--primary)] hover:opacity-80 transition-opacity" style="line-height: 1;">
+          <NuxtLink v-if="!showCreateMode && !isBindMode && smtpEnabled" to="/forgot-password" class="text-xs text-[var(--primary)] hover:opacity-80 transition-opacity" style="line-height: 1;">
             忘记密码？
           </NuxtLink>
         </div>
@@ -299,7 +299,7 @@ import { startAuthentication, browserSupportsWebAuthn } from '@simplewebauthn/br
 import { Fingerprint } from 'lucide-vue-next'
 import { usePasswordStrength } from '~/composables/usePasswordStrength'
 
-const { allowOAuthRegistration, fetchSiteConfig } = useSiteConfig()
+const { allowOAuthRegistration, fetchSiteConfig, smtpEnabled } = useSiteConfig()
 
 const route = useRoute()
 const isBindMode = computed(() => route.query.action === 'bind')

--- a/app/composables/usePasswordStrength.ts
+++ b/app/composables/usePasswordStrength.ts
@@ -1,0 +1,49 @@
+import { computed, type Ref } from 'vue'
+
+export function usePasswordStrength(passwordRef: Ref<string>) {
+  return computed(() => {
+    if (!passwordRef.value) {
+      return { width: '0%', colorClass: '', textColorClass: '', text: '' }
+    }
+
+    let score = 0
+    const value = passwordRef.value
+    if (value.length >= 8) score++
+    if (/[a-z]/.test(value)) score++
+    if (/[A-Z]/.test(value)) score++
+    if (/[0-9]/.test(value)) score++
+    if (/[^A-Za-z0-9]/.test(value)) score++
+
+    const scorePercentage = (score / 5) * 100
+
+    if (score < 3) {
+      return {
+        width: `${scorePercentage || 10}%`,
+        colorClass: 'bg-rose-500',
+        textColorClass: 'text-rose-500',
+        text: '弱'
+      }
+    } else if (score < 4) {
+      return {
+        width: `${scorePercentage}%`,
+        colorClass: 'bg-amber-500',
+        textColorClass: 'text-amber-500',
+        text: '中等'
+      }
+    } else if (score < 5) {
+      return {
+        width: `${scorePercentage}%`,
+        colorClass: 'bg-blue-500',
+        textColorClass: 'text-blue-500',
+        text: '强'
+      }
+    } else {
+      return {
+        width: '100%',
+        colorClass: 'bg-emerald-500',
+        textColorClass: 'text-emerald-500',
+        text: '极强'
+      }
+    }
+  })
+}

--- a/app/middleware/auth.global.ts
+++ b/app/middleware/auth.global.ts
@@ -2,7 +2,7 @@ import { useAuth } from '~/composables/useAuth'
 
 export default defineNuxtRouteMiddleware(async (to, from) => {
   const { isAuthenticated, initAuth } = useAuth()
-  const publicRoutes = ['/login', '/', '/auth/error']
+  const publicRoutes = ['/login', '/', '/auth/error', '/forgot-password', '/reset-password']
 
   // 客户端初始化认证状态
   if (import.meta.client && !isAuthenticated.value) {

--- a/app/pages/forgot-password.vue
+++ b/app/pages/forgot-password.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="auth-layout">
-    <div class="auth-container">
+    <div class="auth-main">
+      <div class="auth-container">
       <div class="form-section">
         <div class="form-header">
           <h1 class="form-title">找回密码</h1>
@@ -85,6 +86,7 @@
           </div>
         </form>
       </div>
+      </div>
     </div>
     <SiteFooter />
   </div>
@@ -166,7 +168,16 @@ const handleSubmit = async () => {
   align-items: center;
   justify-content: flex-start;
   padding: 20px;
-  --content-footer-gap: clamp(16px, 4vh, 40px);
+}
+
+.auth-main {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  padding-bottom: clamp(16px, 4vh, 40px);
 }
 
 .auth-container {
@@ -177,8 +188,6 @@ const handleSubmit = async () => {
   border: 1px solid var(--border-primary);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
-  margin: auto 0;
-  margin-bottom: var(--content-footer-gap);
 }
 
 .form-section {

--- a/app/pages/forgot-password.vue
+++ b/app/pages/forgot-password.vue
@@ -164,9 +164,8 @@ const handleSubmit = async () => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   padding: 20px;
-  --content-footer-gap: clamp(16px, 4vh, 40px);
 }
 
 .auth-container {
@@ -177,8 +176,7 @@ const handleSubmit = async () => {
   border: 1px solid var(--border-primary);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
-  margin: auto 0;
-  margin-bottom: var(--content-footer-gap);
+  margin-bottom: clamp(16px, 4vh, 40px);
 }
 
 .form-section {

--- a/app/pages/forgot-password.vue
+++ b/app/pages/forgot-password.vue
@@ -1,0 +1,414 @@
+<template>
+  <div class="auth-layout">
+    <div class="auth-container">
+      <div class="form-section">
+        <div class="form-header">
+          <h1 class="form-title">找回密码</h1>
+          <p class="form-subtitle">请输入您的账号名和绑定的邮箱地址</p>
+          <div class="header-divider" />
+        </div>
+        
+        <div v-if="success" class="success-container">
+          <svg class="success-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+          <p class="success-message">{{ successMessage }}</p>
+          <NuxtLink to="/login" class="back-link-btn">返回登录</NuxtLink>
+        </div>
+
+        <form v-else :class="['auth-form', { 'has-error': !!error }]" @submit.prevent="handleSubmit">
+          <div class="form-group">
+            <label for="username">账号名</label>
+            <div class="input-wrapper">
+              <svg class="input-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                <circle cx="12" cy="7" r="4" />
+              </svg>
+              <input
+                id="username"
+                v-model="username"
+                :class="{ 'input-error': error }"
+                placeholder="请输入您的账号名"
+                required
+                type="text"
+                @input="error = ''"
+              >
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label for="email">绑定的邮箱</label>
+            <div class="input-wrapper">
+              <svg class="input-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+              </svg>
+              <input
+                id="email"
+                v-model="email"
+                :class="{ 'input-error': error }"
+                placeholder="请输入预留的邮箱地址"
+                required
+                type="email"
+                @input="error = ''"
+              >
+            </div>
+          </div>
+
+          <div v-if="error" class="error-container">
+            <svg class="error-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" x2="12" y1="8" y2="12" />
+              <line x1="12" x2="12.01" y1="16" y2="16" />
+            </svg>
+            <span class="error-message">{{ error }}</span>
+          </div>
+
+          <button :disabled="loading" class="submit-btn" type="submit">
+            <svg v-if="loading" class="loading-spinner" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" fill="none" r="10" stroke="currentColor" stroke-dasharray="31.416" stroke-dashoffset="31.416" stroke-linecap="round" stroke-width="2">
+                <animate attributeName="stroke-dasharray" dur="2s" repeatCount="indefinite" values="0 31.416;15.708 15.708;0 31.416"/>
+                <animate attributeName="stroke-dashoffset" dur="2s" repeatCount="indefinite" values="0;-15.708;-31.416"/>
+              </circle>
+            </svg>
+            <span v-if="loading">发送中...</span>
+            <span v-else>发送重置邮件</span>
+          </button>
+          
+          <div class="form-footer">
+            <NuxtLink to="/login" class="back-link">返回登录</NuxtLink>
+          </div>
+        </form>
+      </div>
+    </div>
+    <SiteFooter />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const { siteTitle, initSiteConfig } = useSiteConfig()
+
+const username = ref('')
+const email = ref('')
+const loading = ref(false)
+const error = ref('')
+const success = ref(false)
+const successMessage = ref('')
+
+onMounted(async () => {
+  await initSiteConfig()
+  if (typeof document !== 'undefined' && siteTitle.value) {
+    document.title = `找回密码 | ${siteTitle.value}`
+  }
+})
+
+const handleSubmit = async () => {
+  if (!username.value || !email.value) {
+    error.value = '请填写完整的账号名和邮箱'
+    return
+  }
+
+  loading.value = true
+  error.value = ''
+
+  try {
+    const response = await $fetch('/api/auth/forgot-password', {
+      method: 'POST',
+      body: {
+        username: username.value,
+        email: email.value
+      }
+    })
+
+    if (response.success) {
+      success.value = true
+      successMessage.value = response.message || '重置邮件已发送'
+    }
+  } catch (err) {
+    error.value = err.data?.message || err.message || '请求失败，请稍后重试'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.auth-layout {
+  min-height: 100vh;
+  background: var(--bg-primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 20px;
+  --content-footer-gap: clamp(16px, 4vh, 40px);
+}
+
+.auth-container {
+  width: 100%;
+  max-width: 480px;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--border-primary);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  margin: auto 0;
+  margin-bottom: var(--content-footer-gap);
+}
+
+.form-section {
+  padding: 40px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-secondary);
+}
+
+.form-header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.form-title {
+  font-size: 24px;
+  font-weight: var(--font-bold);
+  margin: 0 0 8px 0;
+  color: var(--text-primary);
+}
+
+.form-subtitle {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.header-divider {
+  height: 1px;
+  background: var(--border-secondary);
+  margin: 20px auto 0;
+  width: 100%;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-group label {
+  font-size: 14px;
+  font-weight: var(--font-medium);
+  color: var(--text-secondary);
+}
+
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper::after {
+  content: '';
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 8px;
+  height: 2px;
+  background: var(--primary);
+  border-radius: 2px;
+  opacity: 0;
+  transform: scaleX(0.2);
+  transition: transform var(--transition-normal), opacity var(--transition-normal);
+}
+
+.input-wrapper:focus-within::after {
+  opacity: 0.35;
+  transform: scaleX(1);
+}
+
+.input-icon {
+  position: absolute;
+  left: 16px;
+  width: 20px;
+  height: 20px;
+  color: var(--text-quaternary);
+  z-index: 1;
+}
+
+.input-wrapper input {
+  width: 100%;
+  padding: 16px 16px 16px 48px;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-lg);
+  color: var(--input-text);
+  font-size: 16px;
+  transition: border-color var(--transition-normal), box-shadow var(--transition-normal);
+}
+
+.input-wrapper input::placeholder {
+  color: var(--input-placeholder);
+}
+
+.input-wrapper input:focus {
+  outline: none;
+  border-color: var(--input-border-focus);
+  box-shadow: var(--input-shadow-focus);
+}
+
+.input-wrapper input:focus + .input-icon,
+.input-wrapper input:not(:placeholder-shown) + .input-icon {
+  color: var(--primary);
+}
+
+.input-wrapper input.input-error {
+  border-color: var(--error);
+  box-shadow: 0 0 0 3px var(--error-light);
+}
+
+.error-container {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  background: var(--error-light);
+  border: 1px solid var(--error-border);
+  border-radius: var(--radius-lg);
+  color: var(--error);
+}
+
+.auth-form.has-error {
+  animation: shake 0.4s ease;
+}
+
+@keyframes shake {
+  0% { transform: translateX(0); }
+  15% { transform: translateX(-6px); }
+  30% { transform: translateX(6px); }
+  45% { transform: translateX(-4px); }
+  60% { transform: translateX(4px); }
+  75% { transform: translateX(-2px); }
+  90% { transform: translateX(2px); }
+  100% { transform: translateX(0); }
+}
+
+.error-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.error-message {
+  font-size: 14px;
+  font-weight: var(--font-medium);
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 16px;
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-text);
+  border: 1px solid var(--btn-primary-border);
+  border-radius: var(--radius-lg);
+  font-size: 16px;
+  font-weight: var(--font-semibold);
+  cursor: pointer;
+  transition: background var(--transition-normal), box-shadow var(--transition-normal), transform var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.submit-btn:hover:not(:disabled) {
+  background: var(--btn-primary-hover);
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-1px);
+}
+
+.submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.loading-spinner {
+  width: 20px;
+  height: 20px;
+}
+
+.form-footer {
+  margin-top: 16px;
+  text-align: center;
+}
+
+.back-link {
+  font-size: 14px;
+  color: var(--primary);
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.back-link:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
+.success-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 20px 0;
+  width: 100%;
+}
+
+.success-icon {
+  width: 64px;
+  height: 64px;
+  color: var(--success, #10b981);
+  margin-bottom: 20px;
+}
+
+.success-message {
+  font-size: 16px;
+  color: var(--text-primary);
+  margin-bottom: 32px;
+  line-height: 1.5;
+}
+
+.back-link-btn {
+  padding: 12px 32px;
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-text);
+  border-radius: var(--radius-lg);
+  text-decoration: none;
+  font-weight: var(--font-medium);
+  transition: opacity 0.2s ease;
+}
+
+.back-link-btn:hover {
+  opacity: 0.9;
+}
+
+@media (max-width: 768px) {
+  .auth-layout {
+    padding: 10px;
+  }
+  .auth-container {
+    border-radius: 16px;
+  }
+  .form-section {
+    padding: 30px 20px;
+  }
+}
+</style>

--- a/app/pages/forgot-password.vue
+++ b/app/pages/forgot-password.vue
@@ -84,7 +84,7 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref, onMounted } from 'vue'
 
 const { siteTitle, initSiteConfig } = useSiteConfig()
@@ -96,11 +96,12 @@ const error = ref('')
 const success = ref(false)
 const successMessage = ref('')
 
+useHead({
+  title: () => siteTitle.value ? `找回密码 | ${siteTitle.value}` : '找回密码'
+})
+
 onMounted(async () => {
   await initSiteConfig()
-  if (typeof document !== 'undefined' && siteTitle.value) {
-    document.title = `找回密码 | ${siteTitle.value}`
-  }
 })
 
 const handleSubmit = async () => {

--- a/app/pages/forgot-password.vue
+++ b/app/pages/forgot-password.vue
@@ -164,8 +164,9 @@ const handleSubmit = async () => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   padding: 20px;
+  --content-footer-gap: clamp(16px, 4vh, 40px);
 }
 
 .auth-container {
@@ -176,7 +177,8 @@ const handleSubmit = async () => {
   border: 1px solid var(--border-primary);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
-  margin-bottom: clamp(16px, 4vh, 40px);
+  margin: auto 0;
+  margin-bottom: var(--content-footer-gap);
 }
 
 .form-section {

--- a/app/pages/forgot-password.vue
+++ b/app/pages/forgot-password.vue
@@ -17,7 +17,7 @@
         </div>
 
         <form v-else :class="['auth-form', { 'has-error': !!error }]" @submit.prevent="handleSubmit">
-          <div class="form-group">
+          <div class="form-group" v-if="step === 1">
             <label for="username">账号名</label>
             <div class="input-wrapper">
               <svg class="input-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -36,8 +36,11 @@
             </div>
           </div>
 
-          <div class="form-group">
-            <label for="email">绑定的邮箱</label>
+          <div class="form-group" v-if="step === 2">
+            <label for="email">验证邮箱</label>
+            <p class="text-sm text-[var(--text-secondary)] mb-2">
+              系统检测到该账号绑定了邮箱：<strong class="text-[var(--primary)]">{{ maskedEmail }}</strong>
+            </p>
             <div class="input-wrapper">
               <svg class="input-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
@@ -46,7 +49,7 @@
                 id="email"
                 v-model="email"
                 :class="{ 'input-error': error }"
-                placeholder="请输入预留的邮箱地址"
+                placeholder="请补全完整的邮箱地址"
                 required
                 type="email"
                 @input="error = ''"
@@ -70,11 +73,14 @@
                 <animate attributeName="stroke-dashoffset" dur="2s" repeatCount="indefinite" values="0;-15.708;-31.416"/>
               </circle>
             </svg>
-            <span v-if="loading">发送中...</span>
-            <span v-else>发送重置邮件</span>
+            <span v-if="loading">{{ step === 1 ? '验证中...' : '发送中...' }}</span>
+            <span v-else>{{ step === 1 ? '下一步' : '发送重置邮件' }}</span>
           </button>
           
           <div class="form-footer">
+            <button v-if="step === 2" type="button" @click="step = 1; error = '';" class="back-link mr-4" style="background: none; border: none; cursor: pointer;">
+              上一步
+            </button>
             <NuxtLink to="/login" class="back-link">返回登录</NuxtLink>
           </div>
         </form>
@@ -95,6 +101,8 @@ const loading = ref(false)
 const error = ref('')
 const success = ref(false)
 const successMessage = ref('')
+const step = ref(1)
+const maskedEmail = ref('')
 
 useHead({
   title: () => siteTitle.value ? `找回密码 | ${siteTitle.value}` : '找回密码'
@@ -105,26 +113,41 @@ onMounted(async () => {
 })
 
 const handleSubmit = async () => {
-  if (!username.value || !email.value) {
-    error.value = '请填写完整的账号名和邮箱'
-    return
+  if (step.value === 1) {
+    if (!username.value) {
+      error.value = '请输入账号名'
+      return
+    }
+  } else if (step.value === 2) {
+    if (!email.value) {
+      error.value = '请补全邮箱地址'
+      return
+    }
   }
 
   loading.value = true
   error.value = ''
 
   try {
+    const body = step.value === 1 
+      ? { username: username.value }
+      : { username: username.value, email: email.value }
+
     const response = await $fetch('/api/auth/forgot-password', {
       method: 'POST',
-      body: {
-        username: username.value,
-        email: email.value
-      }
+      body
     })
 
     if (response.success) {
-      success.value = true
-      successMessage.value = response.message || '重置邮件已发送'
+      if (response.step === 2) {
+        // 进入补全邮箱步骤
+        step.value = 2
+        maskedEmail.value = response.maskedEmail || ''
+      } else if (response.step === 3) {
+        // 成功发送邮件
+        success.value = true
+        successMessage.value = response.message || '重置邮件已发送'
+      }
     }
   } catch (err) {
     error.value = err.data?.message || err.message || '请求失败，请稍后重试'

--- a/app/pages/reset-password.vue
+++ b/app/pages/reset-password.vue
@@ -135,7 +135,7 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 
 import { usePasswordStrength } from '~/composables/usePasswordStrength'
@@ -155,11 +155,12 @@ const successMessage = ref('')
 
 const passwordStrength = usePasswordStrength(password)
 
+useHead({
+  title: () => siteTitle.value ? `重置密码 | ${siteTitle.value}` : '重置密码'
+})
+
 onMounted(async () => {
   await initSiteConfig()
-  if (typeof document !== 'undefined' && siteTitle.value) {
-    document.title = `重置密码 | ${siteTitle.value}`
-  }
 })
 
 const handleSubmit = async () => {

--- a/app/pages/reset-password.vue
+++ b/app/pages/reset-password.vue
@@ -138,6 +138,8 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 
+import { usePasswordStrength } from '~/composables/usePasswordStrength'
+
 const { siteTitle, initSiteConfig } = useSiteConfig()
 const route = useRoute()
 
@@ -151,54 +153,12 @@ const error = ref('')
 const success = ref(false)
 const successMessage = ref('')
 
+const passwordStrength = usePasswordStrength(password)
+
 onMounted(async () => {
   await initSiteConfig()
   if (typeof document !== 'undefined' && siteTitle.value) {
     document.title = `重置密码 | ${siteTitle.value}`
-  }
-})
-
-const passwordStrength = computed(() => {
-  if (!password.value) return { width: '0%', colorClass: '', textColorClass: '', text: '' }
-
-  let score = 0
-  const value = password.value
-  if (value.length >= 8) score++
-  if (/[a-z]/.test(value)) score++
-  if (/[A-Z]/.test(value)) score++
-  if (/[0-9]/.test(value)) score++
-  if (/[^A-Za-z0-9]/.test(value)) score++
-
-  const scorePercentage = (score / 5) * 100
-
-  if (score < 3) {
-    return {
-      width: `${scorePercentage || 10}%`,
-      colorClass: 'bg-rose-500',
-      textColorClass: 'text-rose-500',
-      text: '弱'
-    }
-  } else if (score < 4) {
-    return {
-      width: `${scorePercentage}%`,
-      colorClass: 'bg-amber-500',
-      textColorClass: 'text-amber-500',
-      text: '中等'
-    }
-  } else if (score < 5) {
-    return {
-      width: `${scorePercentage}%`,
-      colorClass: 'bg-blue-500',
-      textColorClass: 'text-blue-500',
-      text: '强'
-    }
-  } else {
-    return {
-      width: '100%',
-      colorClass: 'bg-emerald-500',
-      textColorClass: 'text-emerald-500',
-      text: '极强'
-    }
   }
 })
 

--- a/app/pages/reset-password.vue
+++ b/app/pages/reset-password.vue
@@ -210,9 +210,8 @@ const handleSubmit = async () => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   padding: 20px;
-  --content-footer-gap: clamp(16px, 4vh, 40px);
 }
 
 .auth-container {
@@ -223,8 +222,7 @@ const handleSubmit = async () => {
   border: 1px solid var(--border-primary);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
-  margin: auto 0;
-  margin-bottom: var(--content-footer-gap);
+  margin-bottom: clamp(16px, 4vh, 40px);
 }
 
 .form-section {

--- a/app/pages/reset-password.vue
+++ b/app/pages/reset-password.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="auth-layout">
-    <div class="auth-container">
+    <div class="auth-main">
+      <div class="auth-container">
       <div class="form-section">
         <div class="form-header">
           <h1 class="form-title">重置密码</h1>
@@ -130,6 +131,7 @@
           </div>
         </form>
       </div>
+      </div>
     </div>
     <SiteFooter />
   </div>
@@ -212,7 +214,16 @@ const handleSubmit = async () => {
   align-items: center;
   justify-content: flex-start;
   padding: 20px;
-  --content-footer-gap: clamp(16px, 4vh, 40px);
+}
+
+.auth-main {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  padding-bottom: clamp(16px, 4vh, 40px);
 }
 
 .auth-container {
@@ -223,8 +234,6 @@ const handleSubmit = async () => {
   border: 1px solid var(--border-primary);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
-  margin: auto 0;
-  margin-bottom: var(--content-footer-gap);
 }
 
 .form-section {

--- a/app/pages/reset-password.vue
+++ b/app/pages/reset-password.vue
@@ -210,8 +210,9 @@ const handleSubmit = async () => {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   padding: 20px;
+  --content-footer-gap: clamp(16px, 4vh, 40px);
 }
 
 .auth-container {
@@ -222,7 +223,8 @@ const handleSubmit = async () => {
   border: 1px solid var(--border-primary);
   box-shadow: var(--shadow-lg);
   overflow: hidden;
-  margin-bottom: clamp(16px, 4vh, 40px);
+  margin: auto 0;
+  margin-bottom: var(--content-footer-gap);
 }
 
 .form-section {

--- a/app/pages/reset-password.vue
+++ b/app/pages/reset-password.vue
@@ -1,0 +1,549 @@
+<template>
+  <div class="auth-layout">
+    <div class="auth-container">
+      <div class="form-section">
+        <div class="form-header">
+          <h1 class="form-title">重置密码</h1>
+          <p class="form-subtitle">请设置您的新密码</p>
+          <div class="header-divider" />
+        </div>
+        
+        <div v-if="success" class="success-container">
+          <svg class="success-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+          <p class="success-message">{{ successMessage }}</p>
+          <NuxtLink to="/login" class="back-link-btn">去登录</NuxtLink>
+        </div>
+
+        <form v-else :class="['auth-form', { 'has-error': !!error }]" @submit.prevent="handleSubmit">
+          <div v-if="!token" class="error-container" style="margin-bottom: 20px;">
+            <svg class="error-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" x2="12" y1="8" y2="12" />
+              <line x1="12" x2="12.01" y1="16" y2="16" />
+            </svg>
+            <span class="error-message">重置链接无效或缺少Token，请重新获取邮件</span>
+          </div>
+
+          <!-- 密码字段 -->
+          <div class="form-group">
+            <label for="password">新密码</label>
+            <div class="input-wrapper">
+              <svg class="input-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <rect height="11" rx="2" ry="2" width="18" x="3" y="11" />
+                <circle cx="12" cy="16" r="1" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+              </svg>
+              <input
+                id="password"
+                v-model="password"
+                :class="{ 'input-error': error }"
+                :type="showPassword ? 'text' : 'password'"
+                placeholder="至少8个字符"
+                required
+                @input="error = ''"
+              >
+              <button class="password-toggle" type="button" @click="showPassword = !showPassword">
+                <svg v-if="showPassword" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+                  <line x1="1" x2="23" y1="1" y2="23" />
+                </svg>
+                <svg v-else fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              </button>
+            </div>
+            
+            <!-- 密码强度指示器 -->
+            <div v-if="password" class="px-1 pt-1 space-y-2 mt-1">
+              <div class="h-1 w-full bg-[var(--input-border)] rounded-full overflow-hidden">
+                <div
+                  class="h-full transition-all duration-500"
+                  :class="passwordStrength.colorClass"
+                  :style="{ width: passwordStrength.width }"
+                />
+              </div>
+              <div class="flex justify-between items-center">
+                <span class="text-[10px] font-black uppercase tracking-widest text-[var(--text-tertiary)]">密码强度</span>
+                <span class="text-[10px] font-black uppercase tracking-widest" :class="passwordStrength.textColorClass">
+                  {{ passwordStrength.text }}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <!-- 确认密码字段 -->
+          <div class="form-group">
+            <label for="confirmPassword">确认新密码</label>
+            <div class="input-wrapper">
+              <svg class="input-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <rect height="11" rx="2" ry="2" width="18" x="3" y="11" />
+                <circle cx="12" cy="16" r="1" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+              </svg>
+              <input
+                id="confirmPassword"
+                v-model="confirmPassword"
+                :class="{ 'input-error': error }"
+                :type="showConfirmPassword ? 'text' : 'password'"
+                placeholder="请再次输入新密码"
+                required
+                @input="error = ''"
+              >
+              <button class="password-toggle" type="button" @click="showConfirmPassword = !showConfirmPassword">
+                <svg v-if="showConfirmPassword" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+                  <line x1="1" x2="23" y1="1" y2="23" />
+                </svg>
+                <svg v-else fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div v-if="error" class="error-container">
+            <svg class="error-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" x2="12" y1="8" y2="12" />
+              <line x1="12" x2="12.01" y1="16" y2="16" />
+            </svg>
+            <span class="error-message">{{ error }}</span>
+          </div>
+
+          <button :disabled="loading || !token" class="submit-btn" type="submit">
+            <svg v-if="loading" class="loading-spinner" viewBox="0 0 24 24">
+              <circle cx="12" cy="12" fill="none" r="10" stroke="currentColor" stroke-dasharray="31.416" stroke-dashoffset="31.416" stroke-linecap="round" stroke-width="2">
+                <animate attributeName="stroke-dasharray" dur="2s" repeatCount="indefinite" values="0 31.416;15.708 15.708;0 31.416"/>
+                <animate attributeName="stroke-dashoffset" dur="2s" repeatCount="indefinite" values="0;-15.708;-31.416"/>
+              </circle>
+            </svg>
+            <span v-if="loading">重置中...</span>
+            <span v-else>确认重置</span>
+          </button>
+          
+          <div class="form-footer">
+            <NuxtLink to="/login" class="back-link">返回登录</NuxtLink>
+          </div>
+        </form>
+      </div>
+    </div>
+    <SiteFooter />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+const { siteTitle, initSiteConfig } = useSiteConfig()
+const route = useRoute()
+
+const token = computed(() => route.query.token || '')
+const password = ref('')
+const confirmPassword = ref('')
+const showPassword = ref(false)
+const showConfirmPassword = ref(false)
+const loading = ref(false)
+const error = ref('')
+const success = ref(false)
+const successMessage = ref('')
+
+onMounted(async () => {
+  await initSiteConfig()
+  if (typeof document !== 'undefined' && siteTitle.value) {
+    document.title = `重置密码 | ${siteTitle.value}`
+  }
+})
+
+const passwordStrength = computed(() => {
+  if (!password.value) return { width: '0%', colorClass: '', textColorClass: '', text: '' }
+
+  let score = 0
+  const value = password.value
+  if (value.length >= 8) score++
+  if (/[a-z]/.test(value)) score++
+  if (/[A-Z]/.test(value)) score++
+  if (/[0-9]/.test(value)) score++
+  if (/[^A-Za-z0-9]/.test(value)) score++
+
+  const scorePercentage = (score / 5) * 100
+
+  if (score < 3) {
+    return {
+      width: `${scorePercentage || 10}%`,
+      colorClass: 'bg-rose-500',
+      textColorClass: 'text-rose-500',
+      text: '弱'
+    }
+  } else if (score < 4) {
+    return {
+      width: `${scorePercentage}%`,
+      colorClass: 'bg-amber-500',
+      textColorClass: 'text-amber-500',
+      text: '中等'
+    }
+  } else if (score < 5) {
+    return {
+      width: `${scorePercentage}%`,
+      colorClass: 'bg-blue-500',
+      textColorClass: 'text-blue-500',
+      text: '强'
+    }
+  } else {
+    return {
+      width: '100%',
+      colorClass: 'bg-emerald-500',
+      textColorClass: 'text-emerald-500',
+      text: '极强'
+    }
+  }
+})
+
+const handleSubmit = async () => {
+  if (!token.value) {
+    error.value = '重置链接无效'
+    return
+  }
+
+  if (password.value !== confirmPassword.value) {
+    error.value = '两次输入的密码不一致'
+    return
+  }
+
+  if (password.value.length < 8) {
+    error.value = '密码长度不能少于8个字符'
+    return
+  }
+
+  loading.value = true
+  error.value = ''
+
+  try {
+    const response = await $fetch('/api/auth/reset-password', {
+      method: 'POST',
+      body: {
+        token: token.value,
+        newPassword: password.value
+      }
+    })
+
+    if (response.success) {
+      success.value = true
+      successMessage.value = response.message || '密码重置成功'
+    }
+  } catch (err) {
+    error.value = err.data?.message || err.message || '重置失败，请重试'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.auth-layout {
+  min-height: 100vh;
+  background: var(--bg-primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 20px;
+  --content-footer-gap: clamp(16px, 4vh, 40px);
+}
+
+.auth-container {
+  width: 100%;
+  max-width: 480px;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--border-primary);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  margin: auto 0;
+  margin-bottom: var(--content-footer-gap);
+}
+
+.form-section {
+  padding: 40px 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-secondary);
+}
+
+.form-header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.form-title {
+  font-size: 24px;
+  font-weight: var(--font-bold);
+  margin: 0 0 8px 0;
+  color: var(--text-primary);
+}
+
+.form-subtitle {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.header-divider {
+  height: 1px;
+  background: var(--border-secondary);
+  margin: 20px auto 0;
+  width: 100%;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-group label {
+  font-size: 14px;
+  font-weight: var(--font-medium);
+  color: var(--text-secondary);
+}
+
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper::after {
+  content: '';
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 8px;
+  height: 2px;
+  background: var(--primary);
+  border-radius: 2px;
+  opacity: 0;
+  transform: scaleX(0.2);
+  transition: transform var(--transition-normal), opacity var(--transition-normal);
+}
+
+.input-wrapper:focus-within::after {
+  opacity: 0.35;
+  transform: scaleX(1);
+}
+
+.input-icon {
+  position: absolute;
+  left: 16px;
+  width: 20px;
+  height: 20px;
+  color: var(--text-quaternary);
+  z-index: 1;
+}
+
+.input-wrapper input {
+  width: 100%;
+  padding: 16px 16px 16px 48px;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-lg);
+  color: var(--input-text);
+  font-size: 16px;
+  transition: border-color var(--transition-normal), box-shadow var(--transition-normal);
+}
+
+.input-wrapper input::placeholder {
+  color: var(--input-placeholder);
+}
+
+.input-wrapper input:focus {
+  outline: none;
+  border-color: var(--input-border-focus);
+  box-shadow: var(--input-shadow-focus);
+}
+
+.input-wrapper input:focus + .input-icon,
+.input-wrapper input:not(:placeholder-shown) + .input-icon {
+  color: var(--primary);
+}
+
+.input-wrapper input.input-error {
+  border-color: var(--error);
+  box-shadow: 0 0 0 3px var(--error-light);
+}
+
+.password-toggle {
+  position: absolute;
+  right: 16px;
+  width: 20px;
+  height: 20px;
+  background: none;
+  border: none;
+  color: var(--text-quaternary);
+  cursor: pointer;
+  transition: color 0.2s ease, transform var(--transition-fast);
+  z-index: 1;
+}
+
+.password-toggle:hover {
+  color: var(--text-primary);
+}
+
+.password-toggle:active {
+  transform: scale(0.95);
+}
+
+.password-toggle svg {
+  width: 100%;
+  height: 100%;
+}
+
+.error-container {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  background: var(--error-light);
+  border: 1px solid var(--error-border);
+  border-radius: var(--radius-lg);
+  color: var(--error);
+}
+
+.auth-form.has-error {
+  animation: shake 0.4s ease;
+}
+
+@keyframes shake {
+  0% { transform: translateX(0); }
+  15% { transform: translateX(-6px); }
+  30% { transform: translateX(6px); }
+  45% { transform: translateX(-4px); }
+  60% { transform: translateX(4px); }
+  75% { transform: translateX(-2px); }
+  90% { transform: translateX(2px); }
+  100% { transform: translateX(0); }
+}
+
+.error-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.error-message {
+  font-size: 14px;
+  font-weight: var(--font-medium);
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 16px;
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-text);
+  border: 1px solid var(--btn-primary-border);
+  border-radius: var(--radius-lg);
+  font-size: 16px;
+  font-weight: var(--font-semibold);
+  cursor: pointer;
+  transition: background var(--transition-normal), box-shadow var(--transition-normal), transform var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.submit-btn:hover:not(:disabled) {
+  background: var(--btn-primary-hover);
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-1px);
+}
+
+.submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.loading-spinner {
+  width: 20px;
+  height: 20px;
+}
+
+.form-footer {
+  margin-top: 16px;
+  text-align: center;
+}
+
+.back-link {
+  font-size: 14px;
+  color: var(--primary);
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.back-link:hover {
+  opacity: 0.8;
+  text-decoration: underline;
+}
+
+.success-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 20px 0;
+  width: 100%;
+}
+
+.success-icon {
+  width: 64px;
+  height: 64px;
+  color: var(--success, #10b981);
+  margin-bottom: 20px;
+}
+
+.success-message {
+  font-size: 16px;
+  color: var(--text-primary);
+  margin-bottom: 32px;
+  line-height: 1.5;
+}
+
+.back-link-btn {
+  padding: 12px 32px;
+  background: var(--btn-primary-bg);
+  color: var(--btn-primary-text);
+  border-radius: var(--radius-lg);
+  text-decoration: none;
+  font-weight: var(--font-medium);
+  transition: opacity 0.2s ease;
+}
+
+.back-link-btn:hover {
+  opacity: 0.9;
+}
+
+@media (max-width: 768px) {
+  .auth-layout {
+    padding: 10px;
+  }
+  .auth-container {
+    border-radius: 16px;
+  }
+  .form-section {
+    padding: 30px 20px;
+  }
+}
+</style>

--- a/server/api/auth/forgot-password.post.ts
+++ b/server/api/auth/forgot-password.post.ts
@@ -71,11 +71,20 @@ export default defineEventHandler(async (event) => {
       }
       const token = JWTEnhanced.sign(payload, { expiresIn: '15m' })
 
-      // 修复 Host Header Injection 风险，使用安全的获取方式
-      const host = getRequestHost(event)
-      const finalProtocol = getRequestProtocol(event)
+      // 修复 Host Header Injection 风险，优先使用环境变量中配置的主机名
+      const config = useRuntimeConfig()
+      let resetLink = ''
       
-      const resetLink = `${finalProtocol}://${host}/reset-password?token=${token}`
+      if (config.public.host) {
+        // 如果配置了主机名，则直接使用
+        const protocol = config.public.host.startsWith('http') ? '' : (process.env.NODE_ENV === 'production' ? 'https://' : 'http://')
+        resetLink = `${protocol}${config.public.host}/reset-password?token=${token}`
+      } else {
+        // 降级回退：使用安全的请求头获取方式
+        const host = getRequestHost(event)
+        const finalProtocol = getRequestProtocol(event)
+        resetLink = `${finalProtocol}://${host}/reset-password?token=${token}`
+      }
 
       const smtp = SmtpService.getInstance()
       

--- a/server/api/auth/forgot-password.post.ts
+++ b/server/api/auth/forgot-password.post.ts
@@ -4,8 +4,23 @@ import { eq } from 'drizzle-orm'
 import { SmtpService } from '~~/server/services/smtpService'
 import { JWTEnhanced } from '~~/server/utils/jwt-enhanced'
 import { getClientIP } from '~~/server/utils/ip-utils'
+import { checkRateLimit } from '~~/server/utils/rateLimiter'
 
 export default defineEventHandler(async (event) => {
+  const clientIP = getClientIP(event)
+  
+  // IP 级别限流：每小时最多 5 次请求
+  const rateLimitKey = `forgot_password_ip:${clientIP}`
+  const limitResult = checkRateLimit(rateLimitKey, 5, 60 * 60 * 1000)
+  
+  if (!limitResult.isAllowed) {
+    const waitMinutes = Math.ceil((limitResult.resetTime - Date.now()) / 60000)
+    throw createError({ 
+      statusCode: 429, 
+      message: `操作过于频繁，请等待 ${waitMinutes} 分钟后再试` 
+    })
+  }
+
   const body = await readBody(event)
   const { username, email } = body
 
@@ -17,24 +32,21 @@ export default defineEventHandler(async (event) => {
     const userResult = await db.select().from(users).where(eq(users.username, username)).limit(1)
     const user = userResult[0]
 
-    // 为了防止恶意枚举账号，无论是否匹配，都返回相同的成功提示
+    // 无论是否匹配，都返回相同的成功提示
     if (user && user.email && user.email.toLowerCase() === email.toLowerCase()) {
       const payload = {
         type: 'password_reset',
         userId: user.id,
-        hash: user.password // 密码哈希，一旦密码被修改，旧链接立即失效
+        hash: user.password
       }
-      // 令牌15分钟有效
       const token = JWTEnhanced.sign(payload, { expiresIn: '15m' })
 
-      const host = getRequestHeader(event, 'host')
-      const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http'
-      const forwardedProto = getRequestHeader(event, 'x-forwarded-proto')
-      const finalProtocol = forwardedProto || protocol
+      // 修复 Host Header Injection 风险，使用安全的获取方式
+      const host = getRequestHost(event)
+      const finalProtocol = getRequestProtocol(event)
       
       const resetLink = `${finalProtocol}://${host}/reset-password?token=${token}`
 
-      const clientIP = getClientIP(event)
       const smtp = SmtpService.getInstance()
       
       // 确保SMTP配置已初始化
@@ -47,7 +59,6 @@ export default defineEventHandler(async (event) => {
         clientIP
       )
 
-      // 异步发送邮件，不阻塞响应
       event.waitUntil(
         smtp.sendMail(user.email, '重置密码 | VoiceHub', htmlContent, undefined, clientIP)
           .catch(err => console.error('发送重置密码邮件失败:', err))

--- a/server/api/auth/forgot-password.post.ts
+++ b/server/api/auth/forgot-password.post.ts
@@ -35,10 +35,10 @@ export default defineEventHandler(async (event) => {
     // 如果未提供邮箱，则进入第一步：检查账号并返回掩码邮箱
     if (!email) {
       if (!user) {
-        throw createError({ statusCode: 404, message: '账号不存在' })
+        throw createError({ statusCode: 404, message: '找不到该账号名，请检查是否拼写错误' })
       }
       if (!user.email) {
-        throw createError({ statusCode: 400, message: '该账号未绑定邮箱，无法通过此方式找回密码' })
+        throw createError({ statusCode: 400, message: '该账号未绑定安全邮箱，无法通过此方式找回密码。请联系管理员。' })
       }
       
       // 生成掩码邮箱 (例如: a***b@gmail.com)

--- a/server/api/auth/forgot-password.post.ts
+++ b/server/api/auth/forgot-password.post.ts
@@ -88,10 +88,16 @@ export default defineEventHandler(async (event) => {
         clientIP
       )
 
-      event.waitUntil(
-        smtp.sendMail(user.email, '重置密码 | VoiceHub', htmlContent, undefined, clientIP)
-          .catch(err => console.error('发送重置密码邮件失败:', err))
-      )
+      // 必须等待邮件发送结果，否则前端无法知道发送失败的原因
+      try {
+        await smtp.sendMail(user.email, '重置密码 | VoiceHub', htmlContent, undefined, clientIP)
+      } catch (err: any) {
+        console.error('发送重置密码邮件失败:', err)
+        throw createError({
+          statusCode: 500,
+          message: '邮件发送失败，请稍后重试或联系管理员。详细信息: ' + (err.message || '未知错误')
+        })
+      }
     }
 
     return { 
@@ -101,6 +107,12 @@ export default defineEventHandler(async (event) => {
     }
   } catch (error: any) {
     console.error('重置密码请求失败:', error)
+    
+    // 如果是我们自己抛出的 H3Error，直接抛出以便保留具体状态码和消息
+    if (error.statusCode) {
+      throw error
+    }
+    
     throw createError({
       statusCode: 500,
       message: '系统错误，请稍后重试'

--- a/server/api/auth/forgot-password.post.ts
+++ b/server/api/auth/forgot-password.post.ts
@@ -66,7 +66,8 @@ export default defineEventHandler(async (event) => {
       const payload = {
         type: 'password_reset',
         userId: user.id,
-        hash: user.password
+        // 仅截取密码哈希的前10位，防止完整哈希泄露被离线破解
+        hash: user.password.substring(0, 10)
       }
       const token = JWTEnhanced.sign(payload, { expiresIn: '15m' })
 
@@ -88,16 +89,10 @@ export default defineEventHandler(async (event) => {
         clientIP
       )
 
-      // 必须等待邮件发送结果，否则前端无法知道发送失败的原因
-      try {
-        await smtp.sendMail(user.email, '重置密码 | VoiceHub', htmlContent, undefined, clientIP)
-      } catch (err: any) {
-        console.error('发送重置密码邮件失败:', err)
-        throw createError({
-          statusCode: 500,
-          message: '邮件发送失败，请稍后重试或联系管理员。详细信息: ' + (err.message || '未知错误')
-        })
-      }
+      event.waitUntil(
+        smtp.sendMail(user.email, '重置密码 | VoiceHub', htmlContent, undefined, clientIP)
+          .catch(err => console.error('发送重置密码邮件失败:', err))
+      )
     }
 
     return { 
@@ -107,12 +102,6 @@ export default defineEventHandler(async (event) => {
     }
   } catch (error: any) {
     console.error('重置密码请求失败:', error)
-    
-    // 如果是我们自己抛出的 H3Error，直接抛出以便保留具体状态码和消息
-    if (error.statusCode) {
-      throw error
-    }
-    
     throw createError({
       statusCode: 500,
       message: '系统错误，请稍后重试'

--- a/server/api/auth/forgot-password.post.ts
+++ b/server/api/auth/forgot-password.post.ts
@@ -24,13 +24,42 @@ export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const { username, email } = body
 
-  if (!username || !email) {
-    throw createError({ statusCode: 400, message: '请提供账号名和邮箱地址' })
+  if (!username) {
+    throw createError({ statusCode: 400, message: '请提供账号名' })
   }
 
   try {
     const userResult = await db.select().from(users).where(eq(users.username, username)).limit(1)
     const user = userResult[0]
+
+    // 如果未提供邮箱，则进入第一步：检查账号并返回掩码邮箱
+    if (!email) {
+      if (!user) {
+        throw createError({ statusCode: 404, message: '账号不存在' })
+      }
+      if (!user.email) {
+        throw createError({ statusCode: 400, message: '该账号未绑定邮箱，无法通过此方式找回密码' })
+      }
+      
+      // 生成掩码邮箱 (例如: a***b@gmail.com)
+      const emailParts = user.email.split('@')
+      const name = emailParts[0]
+      const domain = emailParts[1]
+      let maskedName = name
+      if (name && name.length > 2) {
+        maskedName = name.substring(0, 1) + '***' + name.substring(name.length - 1)
+      } else if (name && name.length === 2) {
+        maskedName = name.substring(0, 1) + '*'
+      }
+      const maskedEmail = `${maskedName}@${domain}`
+      
+      return { 
+        success: true, 
+        step: 2,
+        maskedEmail,
+        message: '请输入完整的邮箱地址以验证身份' 
+      }
+    }
 
     // 无论是否匹配，都返回相同的成功提示
     if (user && user.email && user.email.toLowerCase() === email.toLowerCase()) {
@@ -67,6 +96,7 @@ export default defineEventHandler(async (event) => {
 
     return { 
       success: true, 
+      step: 3,
       message: '如果账号名和邮箱匹配，重置密码链接已发送至您的邮箱。请查收并按照邮件中的说明重置密码。' 
     }
   } catch (error: any) {

--- a/server/api/auth/forgot-password.post.ts
+++ b/server/api/auth/forgot-password.post.ts
@@ -1,0 +1,68 @@
+import { db } from '~/drizzle/db'
+import { users } from '~/drizzle/schema'
+import { eq } from 'drizzle-orm'
+import { SmtpService } from '~~/server/services/smtpService'
+import { JWTEnhanced } from '~~/server/utils/jwt-enhanced'
+import { getClientIP } from '~~/server/utils/ip-utils'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { username, email } = body
+
+  if (!username || !email) {
+    throw createError({ statusCode: 400, message: '请提供账号名和邮箱地址' })
+  }
+
+  try {
+    const userResult = await db.select().from(users).where(eq(users.username, username)).limit(1)
+    const user = userResult[0]
+
+    // 为了防止恶意枚举账号，无论是否匹配，都返回相同的成功提示
+    if (user && user.email && user.email.toLowerCase() === email.toLowerCase()) {
+      const payload = {
+        type: 'password_reset',
+        userId: user.id,
+        hash: user.password // 密码哈希，一旦密码被修改，旧链接立即失效
+      }
+      // 令牌15分钟有效
+      const token = JWTEnhanced.sign(payload, { expiresIn: '15m' })
+
+      const host = getRequestHeader(event, 'host')
+      const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http'
+      const forwardedProto = getRequestHeader(event, 'x-forwarded-proto')
+      const finalProtocol = forwardedProto || protocol
+      
+      const resetLink = `${finalProtocol}://${host}/reset-password?token=${token}`
+
+      const clientIP = getClientIP(event)
+      const smtp = SmtpService.getInstance()
+      
+      // 确保SMTP配置已初始化
+      await smtp.initializeSmtpConfig()
+
+      const htmlContent = smtp.generateEmailTemplate(
+        '重置密码',
+        `<p>您好，您请求了重置密码。</p><p>请点击下方按钮重置密码（链接在15分钟内有效）。</p><p style="color:#888">如果您没有请求重置密码，请忽略此邮件。</p>`,
+        resetLink,
+        clientIP
+      )
+
+      // 异步发送邮件，不阻塞响应
+      event.waitUntil(
+        smtp.sendMail(user.email, '重置密码 | VoiceHub', htmlContent, undefined, clientIP)
+          .catch(err => console.error('发送重置密码邮件失败:', err))
+      )
+    }
+
+    return { 
+      success: true, 
+      message: '如果账号名和邮箱匹配，重置密码链接已发送至您的邮箱。请查收并按照邮件中的说明重置密码。' 
+    }
+  } catch (error: any) {
+    console.error('重置密码请求失败:', error)
+    throw createError({
+      statusCode: 500,
+      message: '系统错误，请稍后重试'
+    })
+  }
+})

--- a/server/api/auth/reset-password.post.ts
+++ b/server/api/auth/reset-password.post.ts
@@ -1,0 +1,52 @@
+import { db } from '~/drizzle/db'
+import { users } from '~/drizzle/schema'
+import { eq } from 'drizzle-orm'
+import { JWTEnhanced } from '~~/server/utils/jwt-enhanced'
+import { updateUserPassword } from '~~/server/services/userService'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { token, newPassword } = body
+
+  if (!token || !newPassword) {
+    throw createError({ statusCode: 400, message: '参数不完整' })
+  }
+
+  if (newPassword.length < 8) {
+    throw createError({ statusCode: 400, message: '密码长度不能少于8个字符' })
+  }
+
+  try {
+    // 验证并解码token
+    const decoded = JWTEnhanced.verify(token) as any
+
+    if (decoded.type !== 'password_reset' || !decoded.userId || !decoded.hash) {
+      throw createError({ statusCode: 400, message: '无效的重置链接' })
+    }
+
+    // 获取最新用户信息
+    const userResult = await db.select().from(users).where(eq(users.id, decoded.userId)).limit(1)
+    const user = userResult[0]
+
+    if (!user) {
+      throw createError({ statusCode: 404, message: '用户不存在' })
+    }
+
+    // 验证 hash 是否匹配当前密码
+    // 如果用户已经修改过密码，则 user.password 发生变化，旧 token 失效
+    if (user.password !== decoded.hash) {
+      throw createError({ statusCode: 400, message: '该重置链接已失效（密码已被修改）' })
+    }
+
+    // 更新密码
+    await updateUserPassword(user.id, newPassword)
+
+    return { success: true, message: '密码重置成功，请使用新密码登录' }
+  } catch (error: any) {
+    if (error.name === 'TokenExpiredError') {
+      throw createError({ statusCode: 400, message: '重置链接已过期，请重新申请' })
+    }
+    if (error.statusCode) throw error
+    throw createError({ statusCode: 400, message: '重置密码失败：' + (error.message || '无效链接') })
+  }
+})

--- a/server/api/auth/reset-password.post.ts
+++ b/server/api/auth/reset-password.post.ts
@@ -48,9 +48,9 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 404, message: '用户不存在' })
     }
 
-    // 验证 hash 是否匹配当前密码
+    // 验证 hash 是否匹配当前密码的前10位
     // 如果用户已经修改过密码，则 user.password 发生变化，旧 token 失效
-    if (user.password !== decoded.hash) {
+    if (user.password.substring(0, 10) !== decoded.hash) {
       throw createError({ statusCode: 400, message: '该重置链接已失效（密码已被修改）' })
     }
 

--- a/server/api/auth/reset-password.post.ts
+++ b/server/api/auth/reset-password.post.ts
@@ -3,8 +3,24 @@ import { users } from '~/drizzle/schema'
 import { eq } from 'drizzle-orm'
 import { JWTEnhanced } from '~~/server/utils/jwt-enhanced'
 import { updateUserPassword } from '~~/server/services/userService'
+import { getClientIP } from '~~/server/utils/ip-utils'
+import { checkRateLimit } from '~~/server/utils/rateLimiter'
 
 export default defineEventHandler(async (event) => {
+  const clientIP = getClientIP(event)
+  
+  // IP 级别限流：每小时最多 10 次密码重置尝试
+  const rateLimitKey = `reset_password_ip:${clientIP}`
+  const limitResult = checkRateLimit(rateLimitKey, 10, 60 * 60 * 1000)
+  
+  if (!limitResult.isAllowed) {
+    const waitMinutes = Math.ceil((limitResult.resetTime - Date.now()) / 60000)
+    throw createError({ 
+      statusCode: 429, 
+      message: `重置密码尝试次数过多，请等待 ${waitMinutes} 分钟后再试` 
+    })
+  }
+
   const body = await readBody(event)
   const { token, newPassword } = body
 

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -26,6 +26,8 @@ export default defineEventHandler(async (event) => {
     '/api/auth/oauth-register',
     '/api/auth/2fa/verify',
     '/api/auth/2fa/send-email',
+    '/api/auth/forgot-password', // 找回密码
+    '/api/auth/reset-password', // 重置密码
     '/api/semesters/current',
     '/api/play-times',
     '/api/schedules/public',

--- a/server/services/smtpService.ts
+++ b/server/services/smtpService.ts
@@ -165,8 +165,13 @@ export class SmtpService {
 
   /**
    * 初始化SMTP配置
+   * 仅当配置为空或显式要求强制刷新时才执行
    */
-  async initializeSmtpConfig(): Promise<boolean> {
+  async initializeSmtpConfig(forceRefresh: boolean = false): Promise<boolean> {
+    if (!forceRefresh && this.transporter) {
+      return true
+    }
+
     try {
       const settingsResult = await db.select().from(systemSettings).limit(1)
       const settings = settingsResult[0]

--- a/server/services/smtpService.ts
+++ b/server/services/smtpService.ts
@@ -209,12 +209,14 @@ export class SmtpService {
       }
 
       // 根据端口和安全设置调整配置
+      const isDevelopment = process.env.NODE_ENV === 'development'
+      
       if (port === 587 && !secure) {
         // STARTTLS - 端口587通常使用STARTTLS
         transporterConfig.requireTLS = true
         transporterConfig.tls = {
-          // 不验证服务器证书（用于测试环境）
-          rejectUnauthorized: false
+          // 仅在开发环境中跳过证书校验，生产环境必须校验
+          rejectUnauthorized: !isDevelopment
         }
       } else if (port === 465) {
         // SSL/TLS - 端口465必须使用SSL
@@ -223,7 +225,8 @@ export class SmtpService {
         // 通常不加密
         transporterConfig.secure = false
         transporterConfig.tls = {
-          rejectUnauthorized: false
+          // 仅在开发环境中跳过证书校验
+          rejectUnauthorized: !isDevelopment
         }
       }
 

--- a/server/utils/rateLimiter.ts
+++ b/server/utils/rateLimiter.ts
@@ -1,0 +1,53 @@
+// 简易的内存限流器实现，适用于单实例部署。
+// 如果项目扩展为多实例/Serverless，建议替换为 Redis 或基于数据库的实现
+
+interface RateLimitRecord {
+  count: number
+  resetTime: number
+}
+
+const store = new Map<string, RateLimitRecord>()
+
+/**
+ * 检查并增加限流计数
+ * @param key 限流的唯一键 (如 IP、用户名等)
+ * @param limit 在指定时间窗口内允许的最大请求数
+ * @param windowMs 时间窗口大小（毫秒）
+ * @returns { isAllowed: boolean, remaining: number, resetTime: number }
+ */
+export function checkRateLimit(key: string, limit: number, windowMs: number): { isAllowed: boolean, remaining: number, resetTime: number } {
+  const now = Date.now()
+  let record = store.get(key)
+
+  if (!record || now > record.resetTime) {
+    // 记录不存在或已过期，重置计数
+    record = {
+      count: 1,
+      resetTime: now + windowMs
+    }
+    store.set(key, record)
+    return { isAllowed: true, remaining: limit - 1, resetTime: record.resetTime }
+  }
+
+  // 记录未过期，增加计数
+  record.count++
+  const remaining = Math.max(0, limit - record.count)
+  const isAllowed = record.count <= limit
+
+  return { isAllowed, remaining, resetTime: record.resetTime }
+}
+
+/**
+ * 清理过期的限流记录（可定期调用以防止内存泄漏）
+ */
+export function cleanupRateLimits() {
+  const now = Date.now()
+  for (const [key, record] of store.entries()) {
+    if (now > record.resetTime) {
+      store.delete(key)
+    }
+  }
+}
+
+// 每小时自动清理一次过期记录
+setInterval(cleanupRateLimits, 60 * 60 * 1000)

--- a/server/utils/rateLimiter.ts
+++ b/server/utils/rateLimiter.ts
@@ -1,4 +1,4 @@
-// 简易的内存限流器实现，适用于单实例部署。
+// 简易的内存限流器实现，带有最大容量限制防止内存溢出
 // 如果项目扩展为多实例/Serverless，建议替换为 Redis 或基于数据库的实现
 
 interface RateLimitRecord {
@@ -6,6 +6,7 @@ interface RateLimitRecord {
   resetTime: number
 }
 
+const MAX_STORE_SIZE = 10000 // 最大允许存储的IP记录数
 const store = new Map<string, RateLimitRecord>()
 
 /**
@@ -20,6 +21,11 @@ export function checkRateLimit(key: string, limit: number, windowMs: number): { 
   let record = store.get(key)
 
   if (!record || now > record.resetTime) {
+    // 防止内存溢出：如果达到上限，清理部分旧数据
+    if (store.size >= MAX_STORE_SIZE) {
+      cleanupRateLimits(true)
+    }
+
     // 记录不存在或已过期，重置计数
     record = {
       count: 1,
@@ -38,16 +44,30 @@ export function checkRateLimit(key: string, limit: number, windowMs: number): { 
 }
 
 /**
- * 清理过期的限流记录（可定期调用以防止内存泄漏）
+ * 清理过期的限流记录
+ * @param force 如果为 true，在没有过期数据时也会强制删除最旧的记录
  */
-export function cleanupRateLimits() {
+export function cleanupRateLimits(force = false) {
   const now = Date.now()
+  let deletedCount = 0
+
   for (const [key, record] of store.entries()) {
     if (now > record.resetTime) {
       store.delete(key)
+      deletedCount++
+    }
+  }
+
+  // 如果强制清理且没有过期数据可删，则删除最早插入的记录（利用 Map 的插入顺序特性）
+  if (force && deletedCount === 0 && store.size > 0) {
+    const firstKey = store.keys().next().value
+    if (firstKey !== undefined) {
+      store.delete(firstKey)
     }
   }
 }
 
-// 每小时自动清理一次过期记录
-setInterval(cleanupRateLimits, 60 * 60 * 1000)
+// 尝试设置定时清理器，但在 Serverless 环境中可能不会按预期工作，所以主要依赖惰性清理
+if (typeof setInterval !== 'undefined') {
+  setInterval(() => cleanupRateLimits(false), 60 * 60 * 1000)
+}

--- a/server/utils/rateLimiter.ts
+++ b/server/utils/rateLimiter.ts
@@ -58,11 +58,19 @@ export function cleanupRateLimits(force = false) {
     }
   }
 
-  // 如果强制清理且没有过期数据可删，则删除最早插入的记录（利用 Map 的插入顺序特性）
+  // 如果强制清理且没有过期数据可删，则一次性删除 10% 的最早插入记录
+  // 避免高并发下 Map 始终满载导致频繁触发清理逻辑
   if (force && deletedCount === 0 && store.size > 0) {
-    const firstKey = store.keys().next().value
-    if (firstKey !== undefined) {
-      store.delete(firstKey)
+    const itemsToDelete = Math.ceil(MAX_STORE_SIZE * 0.1)
+    const keys = store.keys()
+    
+    for (let i = 0; i < itemsToDelete; i++) {
+      const key = keys.next().value
+      if (key !== undefined) {
+        store.delete(key)
+      } else {
+        break
+      }
     }
   }
 }


### PR DESCRIPTION
- 实现忘记密码页面，允许用户通过邮箱重置密码
- 创建重置密码API端点，验证令牌并更新用户密码
- 在登录表单中添加忘记密码链接
- 实现密码强度检测和确认密码功能
- 集成SMTP服务发送密码重置邮件
- 添加15分钟有效期的JWT令牌验证机制

Closed #322