### PR TITLE
fix: add PWA manifest link to nuxt.config.ts

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="app" data-theme="dark" data-color-scheme="custom">
-    <!-- 注入 PWA Manifest -->
-    <VitePwaManifest />
-
     <!-- 全局通知容器组件 -->
     <LazyUINotificationContainer ref="notificationContainer" />
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -87,6 +87,7 @@ export default defineNuxtConfig({
       ],
       link: [
         { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+        { rel: 'manifest', href: '/manifest.webmanifest' },
         // 优先加载常规字体，确保页面快速显示
         {
           rel: 'preload',


### PR DESCRIPTION
Closed #346

- Add manifest.webmanifest link in app.head.link
- Remove unused VitePwaManifest component from app.vue

This fixes the issue where the manifest link was missing in the HTML even though the manifest.webmanifest file existed in the build output.