### PR TITLE
refactor(schedule): 允许同一首歌曲存在多个排期

### DIFF
--- a/app/components/Admin/ScheduleManager.vue
+++ b/app/components/Admin/ScheduleManager.vue
@@ -1269,12 +1269,13 @@ const allUnscheduledSongs = computed(() => {
     if (isScheduledInCurrentView) return false
 
     if (activeTab.value === 'replay' || activeTab.value === 'all') {
-            // 重播申请和所有歌曲模式不需要检查 played 状态，只要当前视图没排上就行
-            return true
-          } else {
-            // 普通投稿需未播放，且未在任何日期的排期中
-            return !song.played && !song.scheduled && !scheduledSongIds.value.has(song.id)
-          }
+      // 重播申请和所有歌曲模式不需要检查 played 状态，只要当前视图没排上就行
+      return true
+    } else {
+      // 普通投稿需未播放，且未在任何日期的排期中
+      // 现在允许多排期，不再检查 scheduled 和 scheduledSongIds
+      return !song.played
+    }
   })
 
   // 搜索过滤

--- a/app/drizzle/db.ts
+++ b/app/drizzle/db.ts
@@ -1,5 +1,5 @@
 import {drizzle} from 'drizzle-orm/postgres-js';
-import {and, asc, count, desc, eq, exists, gt, gte, lt, lte, or, sql} from 'drizzle-orm';
+import {and, asc, count, desc, eq, exists, gt, gte, lt, lte, ne, or, sql} from 'drizzle-orm';
 import postgres from 'postgres';
 import * as schema from './schema.ts';
 import {config} from 'dotenv';
@@ -73,7 +73,7 @@ export { client };
 export * from './schema.ts';
 
 // 导出drizzle-orm函数
-export {eq, and, gt, gte, lt, lte, count, exists, desc, asc, or, sql};
+export {eq, ne, and, gt, gte, lt, lte, count, exists, desc, asc, or, sql};
 
 // 数据库连接测试函数
 export async function testConnection() {

--- a/server/api/admin/schedule.post.ts
+++ b/server/api/admin/schedule.post.ts
@@ -48,18 +48,19 @@ export default defineEventHandler(async (event) => {
     }
 
     await db.transaction(async (tx) => {
-      // 检查是否已经为该歌曲创建过排期，如果有则删除旧的排期
-      const existingScheduleResult = await tx
-        .select()
-        .from(schedules)
-        .where(eq(schedules.songId, body.songId))
-        .limit(1)
+      // 注释掉：检查是否已经为该歌曲创建过排期，如果有则删除旧的排期
+      // 允许多个排期绑定同一首歌
+      // const existingScheduleResult = await tx
+      //   .select()
+      //   .from(schedules)
+      //   .where(eq(schedules.songId, body.songId))
+      //   .limit(1)
 
-      const existingSchedule = existingScheduleResult[0]
-      if (existingSchedule) {
-        // 删除现有排期
-        await tx.delete(schedules).where(eq(schedules.id, existingSchedule.id))
-      }
+      // const existingSchedule = existingScheduleResult[0]
+      // if (existingSchedule) {
+      //   // 删除现有排期
+      //   await tx.delete(schedules).where(eq(schedules.id, existingSchedule.id))
+      // }
 
       // 获取序号，如果未提供则查找当天最大序号+1
       let sequence = body.sequence || 1

--- a/server/api/admin/schedule.post.ts
+++ b/server/api/admin/schedule.post.ts
@@ -117,7 +117,7 @@ export default defineEventHandler(async (event) => {
           .from(schedules)
           .where(
             and(
-              eq(schedules.songId, song.id),
+              eq(schedules.songId, schedule.song.id),
               eq(schedules.isDraft, false),
               ne(schedules.id, scheduleResult[0].id)
             )
@@ -147,7 +147,7 @@ export default defineEventHandler(async (event) => {
               )
             )
         } else {
-          console.log(`歌曲 ${song.id} 已有其他正式排期，不再重复发送通知或更新重播状态`)
+          console.log(`歌曲 ${schedule.song.id} 已有其他正式排期，不再重复发送通知或更新重播状态`)
         }
       }
     })

--- a/server/api/admin/schedule.post.ts
+++ b/server/api/admin/schedule.post.ts
@@ -139,7 +139,7 @@ export default defineEventHandler(async (event) => {
           // 标记该歌曲的所有待处理重播申请为已完成
           await tx
             .update(songReplayRequests)
-            .set({ status: 'FULFILLED', updatedAt: new Date() })
+            .set({ status: 'FULFILLED', updatedAt: scheduleResult[0].publishedAt || new Date() })
             .where(
               and(
                 eq(songReplayRequests.songId, schedule.song.id),

--- a/server/api/admin/schedule.post.ts
+++ b/server/api/admin/schedule.post.ts
@@ -139,7 +139,7 @@ export default defineEventHandler(async (event) => {
           // 标记该歌曲的所有待处理重播申请为已完成
           await tx
             .update(songReplayRequests)
-            .set({ status: 'FULFILLED' })
+            .set({ status: 'FULFILLED', updatedAt: new Date() })
             .where(
               and(
                 eq(songReplayRequests.songId, schedule.song.id),

--- a/server/api/admin/schedule.post.ts
+++ b/server/api/admin/schedule.post.ts
@@ -1,6 +1,6 @@
 import { db } from '~/drizzle/db'
 import { playTimes, schedules, songs, users, votes, songReplayRequests } from '~/drizzle/schema'
-import { and, asc, count, desc, eq, gte, lte } from 'drizzle-orm'
+import { and, asc, count, desc, eq, gte, lte, ne } from 'drizzle-orm'
 import { createSongSelectedNotification } from '../../services/notificationService'
 import { cacheService } from '~~/server/services/cacheService'
 
@@ -109,28 +109,46 @@ export default defineEventHandler(async (event) => {
         }
       }
 
-      // 只有在非草稿模式下才创建通知
+      // 只有在非草稿模式下才创建通知和更新重播状态
       if (!isDraft) {
-        await createSongSelectedNotification(
-          schedule.song.requesterId,
-          schedule.song.id,
-          {
-            title: schedule.song.title,
-            artist: schedule.song.artist,
-            playDate: schedule.playDate
-          }
-        )
-
-        // 标记该歌曲的所有待处理重播申请为已完成
-        await tx
-          .update(songReplayRequests)
-          .set({ status: 'FULFILLED' })
+        // 检查该歌曲是否已经有其他已发布的排期
+        const existingPublished = await tx
+          .select({ id: schedules.id })
+          .from(schedules)
           .where(
             and(
-              eq(songReplayRequests.songId, schedule.song.id),
-              eq(songReplayRequests.status, 'PENDING')
+              eq(schedules.songId, song.id),
+              eq(schedules.isDraft, false),
+              ne(schedules.id, scheduleResult[0].id)
             )
           )
+          .limit(1)
+
+        // 如果之前没有正式发布过，才发送通知和更新重播状态
+        if (existingPublished.length === 0) {
+          await createSongSelectedNotification(
+            schedule.song.requesterId,
+            schedule.song.id,
+            {
+              title: schedule.song.title,
+              artist: schedule.song.artist,
+              playDate: schedule.playDate
+            }
+          )
+
+          // 标记该歌曲的所有待处理重播申请为已完成
+          await tx
+            .update(songReplayRequests)
+            .set({ status: 'FULFILLED' })
+            .where(
+              and(
+                eq(songReplayRequests.songId, schedule.song.id),
+                eq(songReplayRequests.status, 'PENDING')
+              )
+            )
+        } else {
+          console.log(`歌曲 ${song.id} 已有其他正式排期，不再重复发送通知或更新重播状态`)
+        }
       }
     })
 

--- a/server/api/admin/schedule.post.ts
+++ b/server/api/admin/schedule.post.ts
@@ -163,7 +163,7 @@ export default defineEventHandler(async (event) => {
 
     // 重新缓存完整的排期列表
     try {
-      // 获取所有排期数据
+      // 获取所有已发布排期数据
       const schedulesData = await db
         .select({
           id: schedules.id,
@@ -193,6 +193,7 @@ export default defineEventHandler(async (event) => {
         .innerJoin(songs, eq(schedules.songId, songs.id))
         .innerJoin(users, eq(songs.requesterId, users.id))
         .leftJoin(playTimes, eq(schedules.playTimeId, playTimes.id))
+        .where(eq(schedules.isDraft, false))
         .orderBy(asc(schedules.playDate))
 
       // 获取所有用户的姓名列表，用于检测同名用户

--- a/server/api/admin/schedule.post.ts
+++ b/server/api/admin/schedule.post.ts
@@ -48,20 +48,6 @@ export default defineEventHandler(async (event) => {
     }
 
     await db.transaction(async (tx) => {
-      // 注释掉：检查是否已经为该歌曲创建过排期，如果有则删除旧的排期
-      // 允许多个排期绑定同一首歌
-      // const existingScheduleResult = await tx
-      //   .select()
-      //   .from(schedules)
-      //   .where(eq(schedules.songId, body.songId))
-      //   .limit(1)
-
-      // const existingSchedule = existingScheduleResult[0]
-      // if (existingSchedule) {
-      //   // 删除现有排期
-      //   await tx.delete(schedules).where(eq(schedules.id, existingSchedule.id))
-      // }
-
       // 获取序号，如果未提供则查找当天最大序号+1
       let sequence = body.sequence || 1
 

--- a/server/api/admin/schedule/bulk-publish.post.ts
+++ b/server/api/admin/schedule/bulk-publish.post.ts
@@ -76,18 +76,54 @@ export default defineEventHandler(async (event) => {
         whereConditions.push(eq(schedules.playTimeId, playTimeId))
       }
 
-      // 2. 查找该时间段内已发布的排期（用于避免重复发送通知）
-      const existingPublished = await tx
+      // 2. 查找全库内已发布的排期（用于避免重复发送通知）
+      // 不要带上当前日期/时段条件，我们要看的是这首歌在全局是否已经发过通知
+      const globalExistingPublished = await tx
         .select({
           songId: schedules.songId
         })
         .from(schedules)
-        .where(and(...whereConditions, eq(schedules.isDraft, false)))
+        .where(eq(schedules.isDraft, false))
 
-      const existingPublishedSongIds = new Set(existingPublished.map((s) => s.songId))
+      const existingPublishedSongIds = new Set(globalExistingPublished.map((s) => s.songId))
 
       // 3. 删除该时间段内的所有排期（包括草稿和已发布）
-      await tx.delete(schedules).where(and(...whereConditions))
+      const deletedSchedules = await tx.delete(schedules).where(and(...whereConditions)).returning({ songId: schedules.songId })
+      
+      // 记录本次删除了哪些歌的排期，如果新排期里没有它们，并且全局也没别的正式排期了，需要恢复 PENDING
+      const deletedSongIds = new Set(deletedSchedules.map(s => s.songId))
+      const newSongIds = new Set(body.songs.map((s: any) => s.songId))
+      
+      for (const oldSongId of deletedSongIds) {
+        if (!newSongIds.has(oldSongId)) {
+          // 这首歌被从当前时段移除了
+          const otherSchedules = await tx
+            .select({ id: schedules.id })
+            .from(schedules)
+            .where(
+              and(
+                eq(schedules.songId, oldSongId),
+                eq(schedules.isDraft, false)
+              )
+            )
+            .limit(1)
+
+          if (otherSchedules.length === 0) {
+            await tx
+              .update(songReplayRequests)
+              .set({
+                status: 'PENDING',
+                updatedAt: new Date()
+              })
+              .where(
+                and(
+                  eq(songReplayRequests.songId, oldSongId),
+                  eq(songReplayRequests.status, 'FULFILLED')
+                )
+              )
+          }
+        }
+      }
 
       // 4. 插入新的排期并处理通知
       const publishedAt = new Date()

--- a/server/api/admin/schedule/bulk-publish.post.ts
+++ b/server/api/admin/schedule/bulk-publish.post.ts
@@ -1,6 +1,6 @@
 import { db } from '~/drizzle/db'
 import { playTimes, schedules, songs, songReplayRequests } from '~/drizzle/schema'
-import { and, eq, gte, lte, inArray } from 'drizzle-orm'
+import { inArray, and, eq, gte, lte } from 'drizzle-orm'
 import { createSongSelectedNotification } from '~~/server/services/notificationService'
 import { cacheService } from '~~/server/services/cacheService'
 import { getClientIP } from '~~/server/utils/ip-utils'
@@ -77,13 +77,20 @@ export default defineEventHandler(async (event) => {
       }
 
       // 2. 查找全库内已发布的排期（用于避免重复发送通知）
-      // 不要带上当前日期/时段条件，我们要看的是这首歌在全局是否已经发过通知
-      const globalExistingPublished = await tx
-        .select({
-          songId: schedules.songId
-        })
-        .from(schedules)
-        .where(eq(schedules.isDraft, false))
+      const newSongIds = new Set(body.songs.map((s: any) => s.songId))
+      const newSongIdsArray = Array.from(newSongIds)
+      
+      const globalExistingPublished = newSongIdsArray.length > 0 
+        ? await tx
+            .select({ songId: schedules.songId })
+            .from(schedules)
+            .where(
+              and(
+                eq(schedules.isDraft, false),
+                inArray(schedules.songId, newSongIdsArray)
+              )
+            )
+        : []
 
       const existingPublishedSongIds = new Set(globalExistingPublished.map((s) => s.songId))
 
@@ -92,36 +99,32 @@ export default defineEventHandler(async (event) => {
       
       // 记录本次删除了哪些歌的排期，如果新排期里没有它们，并且全局也没别的正式排期了，需要恢复 PENDING
       const deletedSongIds = new Set(deletedSchedules.map(s => s.songId))
-      const newSongIds = new Set(body.songs.map((s: any) => s.songId))
-      
-      for (const oldSongId of deletedSongIds) {
-        if (!newSongIds.has(oldSongId)) {
-          // 这首歌被从当前时段移除了
-          const otherSchedules = await tx
-            .select({ id: schedules.id })
-            .from(schedules)
+      const songsToRestore = Array.from(deletedSongIds).filter(id => !newSongIds.has(id))
+
+      if (songsToRestore.length > 0) {
+        const otherPublished = await tx
+          .select({ songId: schedules.songId })
+          .from(schedules)
+          .where(
+            and(
+              eq(schedules.isDraft, false),
+              inArray(schedules.songId, songsToRestore)
+            )
+          )
+
+        const songsWithOtherSchedules = new Set(otherPublished.map(s => s.songId))
+        const finalRestoreIds = songsToRestore.filter(id => !songsWithOtherSchedules.has(id))
+
+        if (finalRestoreIds.length > 0) {
+          await tx
+            .update(songReplayRequests)
+            .set({ status: 'PENDING', updatedAt: new Date() })
             .where(
               and(
-                eq(schedules.songId, oldSongId),
-                eq(schedules.isDraft, false)
+                inArray(songReplayRequests.songId, finalRestoreIds),
+                eq(songReplayRequests.status, 'FULFILLED')
               )
             )
-            .limit(1)
-
-          if (otherSchedules.length === 0) {
-            await tx
-              .update(songReplayRequests)
-              .set({
-                status: 'PENDING',
-                updatedAt: new Date()
-              })
-              .where(
-                and(
-                  eq(songReplayRequests.songId, oldSongId),
-                  eq(songReplayRequests.status, 'FULFILLED')
-                )
-              )
-          }
         }
       }
 

--- a/server/api/admin/schedule/draft.post.ts
+++ b/server/api/admin/schedule/draft.post.ts
@@ -111,40 +111,41 @@ export default defineEventHandler(async (event) => {
         }
       }
 
-      // 检查是否已经为该歌曲创建过排期或草稿，如果有则删除旧的
-      const existingScheduleResult = await tx
-        .select()
-        .from(schedules)
-        .where(eq(schedules.songId, body.songId))
-        .limit(1)
+      // 注释掉：检查是否已经为该歌曲创建过排期或草稿，如果有则删除旧的
+      // 允许多个排期绑定同一首歌
+      // const existingScheduleResult = await tx
+      //   .select()
+      //   .from(schedules)
+      //   .where(eq(schedules.songId, body.songId))
+      //   .limit(1)
 
-      const existingSchedule = existingScheduleResult[0]
-      if (existingSchedule) {
-        // 删除现有排期或草稿
-        await tx.delete(schedules).where(eq(schedules.id, existingSchedule.id))
+      // const existingSchedule = existingScheduleResult[0]
+      // if (existingSchedule) {
+      //   // 删除现有排期或草稿
+      //   await tx.delete(schedules).where(eq(schedules.id, existingSchedule.id))
 
-        // 恢复该歌曲的重播申请状态为 PENDING
-        // 只恢复状态为 FULFILLED 的申请
-        const updatedRequests = await tx
-          .update(songReplayRequests)
-          .set({
-            status: 'PENDING',
-            updatedAt: new Date()
-          })
-          .where(
-            and(
-              eq(songReplayRequests.songId, body.songId),
-              eq(songReplayRequests.status, 'FULFILLED')
-            )
-          )
-          .returning()
+      //   // 恢复该歌曲的重播申请状态为 PENDING
+      //   // 只恢复状态为 FULFILLED 的申请
+      //   const updatedRequests = await tx
+      //     .update(songReplayRequests)
+      //     .set({
+      //       status: 'PENDING',
+      //       updatedAt: new Date()
+      //     })
+      //     .where(
+      //       and(
+      //         eq(songReplayRequests.songId, body.songId),
+      //         eq(songReplayRequests.status, 'FULFILLED')
+      //       )
+      //     )
+      //     .returning()
 
-        if (updatedRequests.length > 0) {
-          console.log(
-            `恢复了 ${updatedRequests.length} 个重播申请状态为 PENDING（草稿保存时删除旧排期）`
-          )
-        }
-      }
+      //   if (updatedRequests.length > 0) {
+      //     console.log(
+      //       `恢复了 ${updatedRequests.length} 个重播申请状态为 PENDING（草稿保存时删除旧排期）`
+      //     )
+      //   }
+      // }
 
       // 获取序号，如果未提供则查找当天最大序号+1
       let sequence = body.sequence || 1

--- a/server/api/admin/schedule/draft.post.ts
+++ b/server/api/admin/schedule/draft.post.ts
@@ -111,42 +111,6 @@ export default defineEventHandler(async (event) => {
         }
       }
 
-      // 注释掉：检查是否已经为该歌曲创建过排期或草稿，如果有则删除旧的
-      // 允许多个排期绑定同一首歌
-      // const existingScheduleResult = await tx
-      //   .select()
-      //   .from(schedules)
-      //   .where(eq(schedules.songId, body.songId))
-      //   .limit(1)
-
-      // const existingSchedule = existingScheduleResult[0]
-      // if (existingSchedule) {
-      //   // 删除现有排期或草稿
-      //   await tx.delete(schedules).where(eq(schedules.id, existingSchedule.id))
-
-      //   // 恢复该歌曲的重播申请状态为 PENDING
-      //   // 只恢复状态为 FULFILLED 的申请
-      //   const updatedRequests = await tx
-      //     .update(songReplayRequests)
-      //     .set({
-      //       status: 'PENDING',
-      //       updatedAt: new Date()
-      //     })
-      //     .where(
-      //       and(
-      //         eq(songReplayRequests.songId, body.songId),
-      //         eq(songReplayRequests.status, 'FULFILLED')
-      //       )
-      //     )
-      //     .returning()
-
-      //   if (updatedRequests.length > 0) {
-      //     console.log(
-      //       `恢复了 ${updatedRequests.length} 个重播申请状态为 PENDING（草稿保存时删除旧排期）`
-      //     )
-      //   }
-      // }
-
       // 获取序号，如果未提供则查找当天最大序号+1
       let sequence = body.sequence || 1
 

--- a/server/api/admin/schedule/publish.post.ts
+++ b/server/api/admin/schedule/publish.post.ts
@@ -1,6 +1,6 @@
 import { db } from '~/drizzle/db'
 import { playTimes, schedules, songs, users, votes, songReplayRequests } from '~/drizzle/schema'
-import { and, asc, count, eq } from 'drizzle-orm'
+import { and, asc, count, eq, ne } from 'drizzle-orm'
 import { createSongSelectedNotification } from '~~/server/services/notificationService'
 import { cacheService } from '~~/server/services/cacheService'
 import { getBeijingTimestamp } from '~/utils/timeUtils'
@@ -91,31 +91,49 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // 发布后发送通知（这是与草稿保存的主要区别）
-    await createSongSelectedNotification(
-      draft.song.requesterId,
-      draft.song.id,
-      {
-        title: draft.song.title,
-        artist: draft.song.artist,
-        playDate: draft.playDate
-      }
-    )
-
-    // 将该歌曲的所有待处理重播申请标记为已完成
-    const updatedRequests = await db
-      .update(songReplayRequests)
-      .set({
-        status: 'FULFILLED',
-        updatedAt: new Date()
-      })
+    // 检查该歌曲是否已经有其他已发布的排期
+    const existingPublished = await db
+      .select({ id: schedules.id })
+      .from(schedules)
       .where(
-        and(eq(songReplayRequests.songId, draft.song.id), eq(songReplayRequests.status, 'PENDING'))
+        and(
+          eq(schedules.songId, draft.song.id),
+          eq(schedules.isDraft, false),
+          ne(schedules.id, body.scheduleId)
+        )
       )
-      .returning()
+      .limit(1)
 
-    if (updatedRequests.length > 0) {
-      console.log(`发布排期：将 ${updatedRequests.length} 个重播申请标记为 FULFILLED`)
+    // 如果之前没有正式发布过，才发送通知和更新重播状态
+    if (existingPublished.length === 0) {
+      // 发布后发送通知
+      await createSongSelectedNotification(
+        draft.song.requesterId,
+        draft.song.id,
+        {
+          title: draft.song.title,
+          artist: draft.song.artist,
+          playDate: draft.playDate
+        }
+      )
+
+      // 将该歌曲的所有待处理重播申请标记为已完成
+      const updatedRequests = await db
+        .update(songReplayRequests)
+        .set({
+          status: 'FULFILLED',
+          updatedAt: new Date()
+        })
+        .where(
+          and(eq(songReplayRequests.songId, draft.song.id), eq(songReplayRequests.status, 'PENDING'))
+        )
+        .returning({ id: songReplayRequests.id })
+
+      if (updatedRequests.length > 0) {
+        console.log(`发布排期：将 ${updatedRequests.length} 个重播申请标记为 FULFILLED`)
+      }
+    } else {
+      console.log(`歌曲 ${draft.song.id} 已有其他正式排期，不再重复发送通知或更新重播状态`)
     }
 
     // 清除相关缓存

--- a/server/api/admin/schedule/publish.post.ts
+++ b/server/api/admin/schedule/publish.post.ts
@@ -124,7 +124,7 @@ export default defineEventHandler(async (event) => {
           .update(songReplayRequests)
           .set({
             status: 'FULFILLED',
-            updatedAt: new Date()
+            updatedAt: publishedAt
           })
           .where(
             and(eq(songReplayRequests.songId, draft.song.id), eq(songReplayRequests.status, 'PENDING'))

--- a/server/api/admin/schedule/publish.post.ts
+++ b/server/api/admin/schedule/publish.post.ts
@@ -69,72 +69,77 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // 更新草稿为已发布状态
-    const publishedAt = new Date(getBeijingTimestamp())
+    // 使用事务包装更新排期和重播申请状态操作，保证原子性
+    const publishedSchedule = await db.transaction(async (tx) => {
+      // 更新草稿为已发布状态
+      const publishedAt = new Date(getBeijingTimestamp())
 
-    const publishResult = await db
-      .update(schedules)
-      .set({
-        isDraft: false,
-        publishedAt: publishedAt,
-        updatedAt: publishedAt
-      })
-      .where(eq(schedules.id, body.scheduleId))
-      .returning()
-
-    const publishedSchedule = publishResult[0]
-
-    if (!publishedSchedule) {
-      throw createError({
-        statusCode: 500,
-        message: '发布排期失败'
-      })
-    }
-
-    // 检查该歌曲是否已经有其他已发布的排期
-    const existingPublished = await db
-      .select({ id: schedules.id })
-      .from(schedules)
-      .where(
-        and(
-          eq(schedules.songId, draft.song.id),
-          eq(schedules.isDraft, false),
-          ne(schedules.id, body.scheduleId)
-        )
-      )
-      .limit(1)
-
-    // 如果之前没有正式发布过，才发送通知和更新重播状态
-    if (existingPublished.length === 0) {
-      // 发布后发送通知
-      await createSongSelectedNotification(
-        draft.song.requesterId,
-        draft.song.id,
-        {
-          title: draft.song.title,
-          artist: draft.song.artist,
-          playDate: draft.playDate
-        }
-      )
-
-      // 将该歌曲的所有待处理重播申请标记为已完成
-      const updatedRequests = await db
-        .update(songReplayRequests)
+      const publishResult = await tx
+        .update(schedules)
         .set({
-          status: 'FULFILLED',
-          updatedAt: new Date()
+          isDraft: false,
+          publishedAt: publishedAt,
+          updatedAt: publishedAt
         })
-        .where(
-          and(eq(songReplayRequests.songId, draft.song.id), eq(songReplayRequests.status, 'PENDING'))
-        )
-        .returning({ id: songReplayRequests.id })
+        .where(eq(schedules.id, body.scheduleId))
+        .returning()
 
-      if (updatedRequests.length > 0) {
-        console.log(`发布排期：将 ${updatedRequests.length} 个重播申请标记为 FULFILLED`)
+      const schedule = publishResult[0]
+
+      if (!schedule) {
+        throw createError({
+          statusCode: 500,
+          message: '发布排期失败'
+        })
       }
-    } else {
-      console.log(`歌曲 ${draft.song.id} 已有其他正式排期，不再重复发送通知或更新重播状态`)
-    }
+
+      // 检查该歌曲是否已经有其他已发布的排期
+      const existingPublished = await tx
+        .select({ id: schedules.id })
+        .from(schedules)
+        .where(
+          and(
+            eq(schedules.songId, draft.song.id),
+            eq(schedules.isDraft, false),
+            ne(schedules.id, body.scheduleId)
+          )
+        )
+        .limit(1)
+
+      // 如果之前没有正式发布过，才发送通知和更新重播状态
+      if (existingPublished.length === 0) {
+        // 发布后发送通知
+        await createSongSelectedNotification(
+          draft.song.requesterId,
+          draft.song.id,
+          {
+            title: draft.song.title,
+            artist: draft.song.artist,
+            playDate: draft.playDate
+          }
+        )
+
+        // 将该歌曲的所有待处理重播申请标记为已完成
+        const updatedRequests = await tx
+          .update(songReplayRequests)
+          .set({
+            status: 'FULFILLED',
+            updatedAt: new Date()
+          })
+          .where(
+            and(eq(songReplayRequests.songId, draft.song.id), eq(songReplayRequests.status, 'PENDING'))
+          )
+          .returning({ id: songReplayRequests.id })
+
+        if (updatedRequests.length > 0) {
+          console.log(`发布排期：将 ${updatedRequests.length} 个重播申请标记为 FULFILLED`)
+        }
+      } else {
+        console.log(`歌曲 ${draft.song.id} 已有其他正式排期，不再重复发送通知或更新重播状态`)
+      }
+      
+      return schedule
+    })
 
     // 清除相关缓存
     try {

--- a/server/api/admin/schedule/remove.post.ts
+++ b/server/api/admin/schedule/remove.post.ts
@@ -59,25 +59,35 @@ export default defineEventHandler(async (event) => {
     console.log(`成功删除排期 ID=${scheduleIdNumber}`)
 
     // 恢复该歌曲的重播申请状态为 PENDING
-    // 只恢复状态不是 PENDING 的申请（可能是 FULFILLED 或其他状态）
+    // 只有当该歌曲没有其他排期时，才恢复重播申请状态
     if (existingSchedule.songId) {
-      const updatedRequests = await db
-        .update(songReplayRequests)
-        .set({
-          status: 'PENDING',
-          updatedAt: new Date()
-        })
-        .where(
-          and(
-            eq(songReplayRequests.songId, existingSchedule.songId),
-            // 不恢复已拒绝的申请
-            eq(songReplayRequests.status, 'FULFILLED')
-          )
-        )
-        .returning()
+      const otherSchedules = await db
+        .select()
+        .from(schedules)
+        .where(eq(schedules.songId, existingSchedule.songId))
+        .limit(1)
 
-      if (updatedRequests.length > 0) {
-        console.log(`恢复了 ${updatedRequests.length} 个重播申请状态为 PENDING`)
+      if (otherSchedules.length === 0) {
+        const updatedRequests = await db
+          .update(songReplayRequests)
+          .set({
+            status: 'PENDING',
+            updatedAt: new Date()
+          })
+          .where(
+            and(
+              eq(songReplayRequests.songId, existingSchedule.songId),
+              // 不恢复已拒绝的申请
+              eq(songReplayRequests.status, 'FULFILLED')
+            )
+          )
+          .returning()
+
+        if (updatedRequests.length > 0) {
+          console.log(`恢复了 ${updatedRequests.length} 个重播申请状态为 PENDING`)
+        }
+      } else {
+        console.log(`该歌曲仍有其他排期，不恢复重播申请状态`)
       }
     }
 

--- a/server/api/admin/schedule/remove.post.ts
+++ b/server/api/admin/schedule/remove.post.ts
@@ -50,46 +50,56 @@ export default defineEventHandler(async (event) => {
 
     console.log(`找到排期 ID=${scheduleIdNumber}, 歌曲=${existingSchedule.songTitle || '未知歌曲'}`)
 
-    // 删除排期
-    const deletedSchedule = await db
-      .delete(schedules)
-      .where(eq(schedules.id, scheduleIdNumber))
-      .returning()
+    // 使用事务包装删除和重播状态更新操作
+    const result = await db.transaction(async (tx) => {
+      // 删除排期
+      const deletedSchedule = await tx
+        .delete(schedules)
+        .where(eq(schedules.id, scheduleIdNumber))
+        .returning()
 
-    console.log(`成功删除排期 ID=${scheduleIdNumber}`)
+      console.log(`成功删除排期 ID=${scheduleIdNumber}`)
 
-    // 恢复该歌曲的重播申请状态为 PENDING
-    // 只有当该歌曲没有其他排期时，才恢复重播申请状态
-    if (existingSchedule.songId) {
-      const otherSchedules = await db
-        .select()
-        .from(schedules)
-        .where(eq(schedules.songId, existingSchedule.songId))
-        .limit(1)
-
-      if (otherSchedules.length === 0) {
-        const updatedRequests = await db
-          .update(songReplayRequests)
-          .set({
-            status: 'PENDING',
-            updatedAt: new Date()
-          })
+      // 恢复该歌曲的重播申请状态为 PENDING
+      // 只有当该歌曲没有其他正式排期（非草稿）时，才恢复重播申请状态
+      if (existingSchedule.songId) {
+        const otherSchedules = await tx
+          .select()
+          .from(schedules)
           .where(
             and(
-              eq(songReplayRequests.songId, existingSchedule.songId),
-              // 不恢复已拒绝的申请
-              eq(songReplayRequests.status, 'FULFILLED')
+              eq(schedules.songId, existingSchedule.songId),
+              eq(schedules.isDraft, false)
             )
           )
-          .returning()
+          .limit(1)
 
-        if (updatedRequests.length > 0) {
-          console.log(`恢复了 ${updatedRequests.length} 个重播申请状态为 PENDING`)
+        if (otherSchedules.length === 0) {
+          const updatedRequests = await tx
+            .update(songReplayRequests)
+            .set({
+              status: 'PENDING',
+              updatedAt: new Date()
+            })
+            .where(
+              and(
+                eq(songReplayRequests.songId, existingSchedule.songId),
+                // 不恢复已拒绝的申请
+                eq(songReplayRequests.status, 'FULFILLED')
+              )
+            )
+            .returning()
+
+          if (updatedRequests.length > 0) {
+            console.log(`恢复了 ${updatedRequests.length} 个重播申请状态为 PENDING`)
+          }
+        } else {
+          console.log(`该歌曲仍有其他正式排期，不恢复重播申请状态`)
         }
-      } else {
-        console.log(`该歌曲仍有其他排期，不恢复重播申请状态`)
       }
-    }
+
+      return deletedSchedule
+    })
 
     // 清除相关缓存
     try {
@@ -102,7 +112,7 @@ export default defineEventHandler(async (event) => {
 
     return {
       success: true,
-      schedule: deletedSchedule
+      schedule: result
     }
   } catch (error: any) {
     console.error('移除排期失败:', error)

--- a/server/api/admin/schedule/remove.post.ts
+++ b/server/api/admin/schedule/remove.post.ts
@@ -1,4 +1,4 @@
-import { db, eq, schedules, songs, songReplayRequests, and } from '~/drizzle/db'
+import { db, eq, ne, schedules, songs, songReplayRequests, and } from '~/drizzle/db'
 import { cacheService } from '~~/server/services/cacheService'
 
 export default defineEventHandler(async (event) => {
@@ -64,12 +64,13 @@ export default defineEventHandler(async (event) => {
       // 只有当该歌曲没有其他正式排期（非草稿）时，才恢复重播申请状态
       if (existingSchedule.songId) {
         const otherSchedules = await tx
-          .select()
+          .select({ id: schedules.id })
           .from(schedules)
           .where(
             and(
               eq(schedules.songId, existingSchedule.songId),
-              eq(schedules.isDraft, false)
+              eq(schedules.isDraft, false),
+              ne(schedules.id, scheduleIdNumber)
             )
           )
           .limit(1)
@@ -88,7 +89,7 @@ export default defineEventHandler(async (event) => {
                 eq(songReplayRequests.status, 'FULFILLED')
               )
             )
-            .returning()
+            .returning({ id: songReplayRequests.id })
 
           if (updatedRequests.length > 0) {
             console.log(`恢复了 ${updatedRequests.length} 个重播申请状态为 PENDING`)

--- a/server/api/songs/index.get.ts
+++ b/server/api/songs/index.get.ts
@@ -499,7 +499,7 @@ export default defineEventHandler(async (event) => {
         createdAt: song.createdAt,
         updatedAt: song.updatedAt,
         requestedAt: formatDateTime(song.createdAt), // 添加请求时间的格式化字符串
-        scheduled: false, // 允许多排期，不再用单一 scheduled 字段过滤
+        scheduled: scheduledSongs.has(song.id), // 是否存在已发布排期
         cover: song.cover || null, // 添加封面字段
         musicPlatform: song.musicPlatform || null, // 添加音乐平台字段
         musicId: song.musicId || null, // 添加音乐ID字段

--- a/server/api/songs/index.get.ts
+++ b/server/api/songs/index.get.ts
@@ -499,7 +499,7 @@ export default defineEventHandler(async (event) => {
         createdAt: song.createdAt,
         updatedAt: song.updatedAt,
         requestedAt: formatDateTime(song.createdAt), // 添加请求时间的格式化字符串
-        scheduled: scheduledSongs.has(song.id), // 添加是否已排期的标志
+        scheduled: false, // 允许多排期，不再用单一 scheduled 字段过滤
         cover: song.cover || null, // 添加封面字段
         musicPlatform: song.musicPlatform || null, // 添加音乐平台字段
         musicId: song.musicId || null, // 添加音乐ID字段


### PR DESCRIPTION
- 移除草稿保存时删除已有排期的逻辑，支持多排期绑定
- 修改排期删除时重播申请状态恢复逻辑，仅在无其他排期时恢复
- 移除正式排期创建时删除已有排期的逻辑，允许重复绑定