### PR TITLE
fix(auth): 修复API请求拦截和时间同步问题

### DIFF
--- a/app/composables/useMusicSources.ts
+++ b/app/composables/useMusicSources.ts
@@ -1210,7 +1210,7 @@ export const useMusicSources = () => {
       const fetchOfficial = async () => {
         if (platform !== 'netease' || !neteaseSource) return
         try {
-          const [lrcResp, yrcResp, ttmlResp] = await Promise.allSettled([
+          const [lrcResp, yrcResp] = await Promise.allSettled([
             $fetch(`${neteaseSource.baseUrl}/lyric`, {
               params: { id: id.toString() },
               timeout: neteaseSource.timeout || 8000
@@ -1218,12 +1218,7 @@ export const useMusicSources = () => {
             $fetch(`${neteaseSource.baseUrl}/lyric/new`, {
               params: { id: id.toString() },
               timeout: neteaseSource.timeout || 8000
-            }),
-            // 尝试获取 TTML 歌词
-            $fetch(`${neteaseSource.baseUrl}/lyric/ttml`, {
-              params: { id: id.toString() },
-              timeout: neteaseSource.timeout || 8000
-            }).catch(() => null)
+            })
           ])
 
           if (lrcResp.status === 'fulfilled' && lrcResp.value?.code === 200) {
@@ -1235,12 +1230,8 @@ export const useMusicSources = () => {
             const yr = yrcResp.value
             if (yr?.yrc?.lyric) resultData.yrc = yr.yrc.lyric
           }
-          if (ttmlResp.status === 'fulfilled' && ttmlResp.value?.code === 200) {
-            const tr = ttmlResp.value
-            if (tr?.ttml && !resultData.ttml) resultData.ttml = tr.ttml
-          }
 
-          if (resultData.lrc || resultData.yrc || resultData.ttml) hasResult = true
+          if (resultData.lrc || resultData.yrc) hasResult = true
         } catch (e: any) {
           console.warn('[getLyrics] NeteaseCloudMusicApi 获取失败:', e?.message || e)
         }

--- a/app/composables/useSyncedTime.ts
+++ b/app/composables/useSyncedTime.ts
@@ -1,0 +1,66 @@
+// 全局状态，保存本地时间与服务器时间的差值
+// offset = serverTime - localTime
+// 仅在客户端有效，服务端默认为0且不进行同步
+let timeOffset = 0
+let hasSynced = false
+
+/**
+ * 获取当前修正后的时间戳 (毫秒)
+ * 可以在任何地方（包括非 Vue 组件环境）安全调用
+ */
+export const getSyncedTimestamp = (): number => {
+  return Date.now() + timeOffset
+}
+
+/**
+ * 获取当前修正后的 Date 对象
+ */
+export const getSyncedDate = (): Date => {
+  return new Date(getSyncedTimestamp())
+}
+
+export function useSyncedTime() {
+  /**
+   * 同步服务器时间
+   * 直接调用本站后端提供的 API（/api/sys/time），以彻底解决任何第三方 API 的 CORS 拦截问题。
+   * 此方法最可靠，并且能够直接对齐后端服务器时间。
+   */
+  const syncTime = async () => {
+    // 服务端本身的时间就是服务器时间，不需要同步
+    if (import.meta.server) {
+      hasSynced = true
+      return
+    }
+
+    if (hasSynced) return
+    
+    try {
+      const startTime = Date.now()
+      // 请求我们自己的后端以获取标准时间戳，避免 CORS
+      const data = await $fetch<{ timestamp: number }>('/api/sys/time')
+      
+      if (data?.timestamp) {
+        const endTime = Date.now()
+        // 估算单向传输延迟
+        const latency = (endTime - startTime) / 2
+        const serverTime = data.timestamp + latency
+        
+        timeOffset = serverTime - endTime
+        hasSynced = true
+        
+        console.log(`[TimeSync] 时间同步完成，与服务器时间相差 ${timeOffset}ms`)
+      }
+    } catch (error) {
+      console.error('[TimeSync] 时间同步失败，将使用本地时间:', error)
+      hasSynced = true // 避免反复重试
+    }
+  }
+
+  return {
+    get offset() { return timeOffset },
+    get hasSynced() { return hasSynced },
+    syncTime,
+    now: getSyncedTimestamp,
+    nowDate: getSyncedDate
+  }
+}

--- a/app/plugins/auth.client.ts
+++ b/app/plugins/auth.client.ts
@@ -9,7 +9,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   // 拦截window.fetch
   window.fetch = async function (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-    // 处理所有API请求 - cookie会自动发送，无需手动添加Authorization头
+    // 处理所有API请求
     if (typeof input === 'string' && input.startsWith('/api')) {
       init = init || {}
       init.headers = init.headers || {}
@@ -20,8 +20,8 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     const response = await originalFetch(input, init)
 
-    // 检查是否为401错误
-    if (response.status === 401) {
+    // 检查是否为401错误，并且该请求属于VoiceHub API
+    if (response.status === 401 && isVoiceHubApi(input)) {
       const currentPath = window.location.pathname
 
       // 如果在登录页面，解析错误响应体并抛出具体错误信息
@@ -62,8 +62,8 @@ export default defineNuxtPlugin((nuxtApp) => {
         try {
           return await originalUseFetch(request, options)
         } catch (error: any) {
-          // 检查是否为401错误
-          if (error?.status === 401 || error?.statusCode === 401) {
+          // 检查是否为401错误，并且该请求属于VoiceHub API
+          if ((error?.status === 401 || error?.statusCode === 401) && isVoiceHubApi(request)) {
             const currentPath = window.location.pathname
 
             // 如果在登录页面，解析错误信息并抛出具体错误

--- a/app/plugins/auth.client.ts
+++ b/app/plugins/auth.client.ts
@@ -1,3 +1,5 @@
+import { isVoiceHubApi } from '~/utils/url'
+
 export default defineNuxtPlugin((nuxtApp) => {
   if (!import.meta.client) {
     return
@@ -10,7 +12,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   // 拦截window.fetch
   window.fetch = async function (input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     // 处理所有API请求
-    if (typeof input === 'string' && input.startsWith('/api')) {
+    if (isVoiceHubApi(input)) {
       init = init || {}
       init.headers = init.headers || {}
 
@@ -53,7 +55,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     if (originalUseFetch) {
       nuxtApp.$fetch = async function (request: any, options: any = {}) {
         // 为所有API请求确保cookie会被发送
-        if (typeof request === 'string' && request.startsWith('/api')) {
+        if (isVoiceHubApi(request)) {
           options.headers = options.headers || {}
           // 确保cookie会被发送
           options.credentials = 'include'

--- a/app/plugins/time-sync.client.ts
+++ b/app/plugins/time-sync.client.ts
@@ -1,0 +1,7 @@
+export default defineNuxtPlugin(async (nuxtApp) => {
+  if (import.meta.client) {
+    const { syncTime } = useSyncedTime()
+    // 异步执行时间同步，不阻塞应用初始化
+    syncTime().catch(console.error)
+  }
+})

--- a/app/utils/neteaseApi.ts
+++ b/app/utils/neteaseApi.ts
@@ -1,3 +1,5 @@
+import { getSyncedTimestamp } from '~/composables/useSyncedTime'
+
 const BASE_URL = '/api/api-enhanced/netease'
 
 export function normalizeNeteaseResponse(data) {
@@ -41,7 +43,7 @@ export async function fetchNetease(endpoint, params = {}, cookie) {
   if (cookie) {
     query.append('cookie', cookie)
   }
-  query.append('timestamp', Date.now().toString())
+  query.append('timestamp', getSyncedTimestamp().toString())
 
   const url = `${BASE_URL}${endpoint}?${query.toString()}`
   const response = await fetch(url)

--- a/app/utils/url.ts
+++ b/app/utils/url.ts
@@ -121,3 +121,35 @@ export const getBilibiliUrl = (song: {
 
   return '#'
 }
+
+/**
+ * 判断 URL 是否属于 VoiceHub 内部 API
+ * @param input 请求的 URL 或 Request 对象
+ * @returns boolean
+ */
+export const isVoiceHubApi = (input: RequestInfo | URL): boolean => {
+  try {
+    let urlStr = ''
+    if (typeof input === 'string') {
+      urlStr = input
+    } else if (input instanceof URL) {
+      urlStr = input.href
+    } else if (input instanceof Request) {
+      urlStr = input.url
+    }
+
+    // 相对路径直接判断
+    if (urlStr.startsWith('/api')) return true
+
+    // 如果在客户端环境中，可以检查是否属于当前域名
+    if (typeof window !== 'undefined') {
+      const urlObj = new URL(urlStr, window.location.origin)
+      return urlObj.origin === window.location.origin && urlObj.pathname.startsWith('/api')
+    }
+
+    return false
+  } catch {
+    return false
+  }
+}
+

--- a/server/api/sys/time.get.ts
+++ b/server/api/sys/time.get.ts
@@ -1,0 +1,69 @@
+import { defineEventHandler } from 'h3'
+
+let timeOffset = 0
+let hasSynced = false
+let isSyncing = false
+
+/**
+ * 尝试从公共 API 获取标准时间并计算服务器的时间偏移量
+ * 优先使用淘宝/美团的 HTTP 接口，因为不需要 UDP (NTP 协议) 的支持
+ */
+async function syncServerTime() {
+  if (hasSynced || isSyncing) return
+  isSyncing = true
+  
+  try {
+    const startTime = Date.now()
+    // 尝试淘宝时间接口
+    const response = await fetch('https://acs.m.taobao.com/gw/mtop.common.getTimestamp/')
+    const data = await response.json()
+    
+    if (data?.data?.t) {
+      const endTime = Date.now()
+      const latency = (endTime - startTime) / 2
+      const realTime = parseInt(data.data.t) + latency
+      timeOffset = realTime - endTime
+      hasSynced = true
+      console.log(`[Server TimeSync] 服务器时间同步成功，偏移量: ${timeOffset}ms`)
+    }
+  } catch (error) {
+    console.warn('[Server TimeSync] 淘宝时间同步失败，尝试备用接口', error)
+    
+    try {
+      const startTime = Date.now()
+      // 尝试美团时间接口
+      const response = await fetch('https://cube.meituan.com/ipromotion/cube/toc/component/base/getServerCurrentTime')
+      const data = await response.json()
+      
+      if (data?.data) {
+        const endTime = Date.now()
+        const latency = (endTime - startTime) / 2
+        const realTime = parseInt(data.data) + latency
+        timeOffset = realTime - endTime
+        hasSynced = true
+        console.log(`[Server TimeSync] 服务器时间同步成功 (备用)，偏移量: ${timeOffset}ms`)
+      }
+    } catch (error2) {
+      console.error('[Server TimeSync] 服务器时间同步完全失败，将使用系统本地时间:', error2)
+      hasSynced = true // 标记为已同步以防止重复请求，使用默认偏移 0
+    }
+  } finally {
+    isSyncing = false
+  }
+}
+
+export default defineEventHandler(async () => {
+  // 如果服务器自身还没同步过时间，则先进行同步
+  if (!hasSynced) {
+    // 设置 2 秒超时，防止因为同步时间导致接口阻塞太久
+    await Promise.race([
+      syncServerTime(),
+      new Promise(resolve => setTimeout(resolve, 2000))
+    ])
+  }
+
+  // 返回修正后的标准时间戳
+  return {
+    timestamp: Date.now() + timeOffset
+  }
+})

--- a/server/api/sys/time.get.ts
+++ b/server/api/sys/time.get.ts
@@ -2,54 +2,75 @@ import { defineEventHandler } from 'h3'
 
 let timeOffset = 0
 let hasSynced = false
-let isSyncing = false
+let syncPromise: Promise<void> | null = null
 
 /**
  * 尝试从公共 API 获取标准时间并计算服务器的时间偏移量
  * 优先使用淘宝/美团的 HTTP 接口，因为不需要 UDP (NTP 协议) 的支持
  */
-async function syncServerTime() {
-  if (hasSynced || isSyncing) return
-  isSyncing = true
-  
+async function doSyncServerTime() {
   try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 1500)
+    
     const startTime = Date.now()
     // 尝试淘宝时间接口
-    const response = await fetch('https://acs.m.taobao.com/gw/mtop.common.getTimestamp/')
+    const response = await fetch('https://acs.m.taobao.com/gw/mtop.common.getTimestamp/', {
+      signal: controller.signal
+    })
+    clearTimeout(timeoutId)
     const data = await response.json()
     
     if (data?.data?.t) {
       const endTime = Date.now()
-      const latency = (endTime - startTime) / 2
+      const latency = Math.round((endTime - startTime) / 2)
       const realTime = parseInt(data.data.t) + latency
       timeOffset = realTime - endTime
       hasSynced = true
       console.log(`[Server TimeSync] 服务器时间同步成功，偏移量: ${timeOffset}ms`)
+      return
     }
   } catch (error) {
     console.warn('[Server TimeSync] 淘宝时间同步失败，尝试备用接口', error)
     
     try {
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), 1500)
+      
       const startTime = Date.now()
       // 尝试美团时间接口
-      const response = await fetch('https://cube.meituan.com/ipromotion/cube/toc/component/base/getServerCurrentTime')
+      const response = await fetch('https://cube.meituan.com/ipromotion/cube/toc/component/base/getServerCurrentTime', {
+        signal: controller.signal
+      })
+      clearTimeout(timeoutId)
       const data = await response.json()
       
       if (data?.data) {
         const endTime = Date.now()
-        const latency = (endTime - startTime) / 2
+        const latency = Math.round((endTime - startTime) / 2)
         const realTime = parseInt(data.data) + latency
         timeOffset = realTime - endTime
         hasSynced = true
         console.log(`[Server TimeSync] 服务器时间同步成功 (备用)，偏移量: ${timeOffset}ms`)
+        return
       }
     } catch (error2) {
       console.error('[Server TimeSync] 服务器时间同步完全失败，将使用系统本地时间:', error2)
       hasSynced = true // 标记为已同步以防止重复请求，使用默认偏移 0
     }
-  } finally {
-    isSyncing = false
   }
+}
+
+async function syncServerTime() {
+  if (hasSynced) return
+  
+  if (!syncPromise) {
+    syncPromise = doSyncServerTime().finally(() => {
+      syncPromise = null
+    })
+  }
+  
+  return syncPromise
 }
 
 export default defineEventHandler(async () => {


### PR DESCRIPTION
- 修改auth.client.ts中的fetch拦截器，添加isVoiceHubApi判断条件来精确处理401错误
- 新增isVoiceHubApi工具函数用于判断URL是否属于VoiceHub内部API
- 移除错误的网易云音乐API中的TTML歌词请求
- 新增服务器时间同步功能，包括sys/time API端点和客户端时间同步插件
- 使用同步后的时间戳替换原来的Date.now()调用以确保时间准确性