### PR TITLE
feat(config): 添加自定义 SEO 和 PWA 配置支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ VoiceHub 实现了细粒度的权限控制系统：
 | REDIS_URL    | 否  | Redis缓存服务连接字符串，填写后自动启用Redis缓存功能 | `redis://default:password@host:port`                                |
 | NITRO_PRESET | 否  | Nitro预设                         | `vercel`                                                            |
 | NUXT_PUBLIC_HOST | 否  | 用于 CORS 和反向代理的主机名验证 | `your-app.com`                                                            |
+| NUXT_PUBLIC_SEO_CONFIG | 否  | 用于自定义 PWA/SEO 配置的 JSON 字符串 | `{"title":"校园广播站点歌系统","shortName":"校园广播","description":"校园广播站点歌系统 - 让你的声音被听见","logo":"/images/logo.png"}` |
 
 ## OAuth 配置
 

--- a/README.md
+++ b/README.md
@@ -647,6 +647,7 @@ VoiceHub/
 │   │   ├── useSiteConfig.js    # 站点配置hooks
 │   │   ├── useSongPlayer.ts    # 歌曲播放器hooks
 │   │   ├── useSongs.ts         # 歌曲管理hooks
+│   │   ├── useSyncedTime.ts    # 时间同步hooks
 │   │   ├── useToast.ts         # Toast提示hooks
 │   ├── drizzle/               # 数据库相关
 │   │   ├── db.ts               # 数据库连接
@@ -671,7 +672,8 @@ VoiceHub/
 │   │   └── year-review.vue     # 年度回顾页面
 │   ├── plugins/               # Nuxt插件
 │   │   ├── auth.client.ts      # 客户端认证插件
-│   │   └── auth.server.ts      # 服务端认证插件
+│   │   ├── auth.server.ts      # 服务端认证插件
+│   │   └── time-sync.client.ts # 客户端时间同步插件
 │   ├── public/                # 静态文件目录
 │   │   ├── images/            # 图片资源
 │   │   │   ├── logo.png       # PNG格式Logo
@@ -899,6 +901,8 @@ VoiceHub/
 │   │   │   ├── submission-status.get.ts # 投稿状态
 │   │   │   ├── vote.post.ts         # 投票
 │   │   │   └── withdraw.post.ts     # 撤回歌曲
+│   │   ├── sys/            # 系统辅助API
+│   │   │   └── time.get.ts          # 获取校准后的服务器时间
 │   │   ├── system/         # 系统API
 │   │   │   ├── location.get.ts      # 获取系统位置信息
 │   │   │   ├── reconnect.post.ts    # 重连数据库

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,6 +20,11 @@ const siteLogo = customSeoConfig.logo || process.env.NUXT_PUBLIC_SITE_LOGO || '/
 
 // 构造绝对路径 Logo URL 用于 SEO 标签，如果没有 host，则回退为相对路径
 const host = process.env.NUXT_PUBLIC_HOST
+if (!host && !siteLogo.startsWith('http') && process.env.NODE_ENV === 'production') {
+  console.warn(
+    '警告: 在生产环境中未配置 NUXT_PUBLIC_HOST，且 siteLogo 使用了相对路径。这可能会导致社交媒体无法正确抓取和显示预览图。'
+  )
+}
 const absoluteLogo = (siteLogo.startsWith('http') || !host)
   ? siteLogo
   : `https://${host}${siteLogo.startsWith('/') ? '' : '/'}${siteLogo}`
@@ -74,10 +79,9 @@ export default defineNuxtConfig({
         casdoor: !!process.env.CASDOOR_CLIENT_ID,
         google: !!process.env.GOOGLE_CLIENT_ID
       },
-      siteTitle: process.env.NUXT_PUBLIC_SITE_TITLE || '校园广播站点歌系统',
-      siteLogo: process.env.NUXT_PUBLIC_SITE_LOGO || '',
-      siteDescription:
-        process.env.NUXT_PUBLIC_SITE_DESCRIPTION || '校园广播站点歌系统 - 让你的声音被听见',
+      siteTitle,
+      siteLogo,
+      siteDescription,
       isNetlify: process.env.NETLIFY === 'true'
     }
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,12 +22,12 @@ const siteLogo = customSeoConfig.logo || process.env.NUXT_PUBLIC_SITE_LOGO || '/
 const host = process.env.NUXT_PUBLIC_HOST
 if (!host && !siteLogo.startsWith('http') && process.env.NODE_ENV === 'production') {
   console.warn(
-    '警告: 在生产环境中未配置 NUXT_PUBLIC_HOST，且 siteLogo 使用了相对路径。这可能会导致社交媒体无法正确抓取和显示预览图。'
+    '警告: 在生产环境中未配置 NUXT_PUBLIC_HOST，且 siteLogo 使用了相对路径。这可能会导致网站无法正确抓取和显示预览图。'
   )
 }
-const absoluteLogo = (siteLogo.startsWith('http') || !host)
+const absoluteLogo = (siteLogo.startsWith('http') || siteLogo.startsWith('//') || !host)
   ? siteLogo
-  : `https://${host}${siteLogo.startsWith('/') ? '' : '/'}${siteLogo}`
+  : (host.startsWith('http') ? '' : 'https://') + host.replace(/\/$/, '') + '/' + siteLogo.replace(/^\//, '')
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,21 @@ import topLevelAwait from 'vite-plugin-top-level-await'
 import glsl from 'vite-plugin-glsl'
 import { fileURLToPath } from 'url'
 
+// 解析自定义 SEO 和 PWA 配置
+let customSeoConfig: any = {}
+try {
+  if (process.env.NUXT_PUBLIC_SEO_CONFIG) {
+    customSeoConfig = JSON.parse(process.env.NUXT_PUBLIC_SEO_CONFIG)
+  }
+} catch (e) {
+  console.warn('解析 NUXT_PUBLIC_SEO_CONFIG 失败，请检查 JSON 格式:', e)
+}
+
+const siteTitle = customSeoConfig.title || process.env.NUXT_PUBLIC_SITE_TITLE || '校园广播站点歌系统'
+const siteShortName = customSeoConfig.shortName || process.env.NUXT_PUBLIC_SITE_TITLE || '校园广播'
+const siteDescription = customSeoConfig.description || process.env.NUXT_PUBLIC_SITE_DESCRIPTION || '校园广播站点歌系统 - 让你的声音被听见'
+const siteLogo = customSeoConfig.logo || process.env.NUXT_PUBLIC_SITE_LOGO || '/images/logo.png'
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2026-01-30',
@@ -64,7 +79,7 @@ export default defineNuxtConfig({
   // 配置环境变量
   app: {
     head: {
-      title: process.env.NUXT_PUBLIC_SITE_TITLE || '校园广播站点歌系统',
+      title: siteTitle,
       meta: [
         { charset: 'utf-8' },
         { name: 'referrer', content: 'no-referrer' },
@@ -75,14 +90,24 @@ export default defineNuxtConfig({
         },
         {
           name: 'description',
-          content:
-            process.env.NUXT_PUBLIC_SITE_DESCRIPTION || '校园广播站点歌系统 - 让你的声音被听见'
+          content: siteDescription
         },
+        // Open Graph 标签
+        { property: 'og:type', content: 'website' },
+        { property: 'og:title', content: siteTitle },
+        { property: 'og:description', content: siteDescription },
+        { property: 'og:site_name', content: siteTitle },
+        { property: 'og:image', content: siteLogo },
+        // Twitter 标签
+        { name: 'twitter:card', content: 'summary' },
+        { name: 'twitter:title', content: siteTitle },
+        { name: 'twitter:description', content: siteDescription },
+        { name: 'twitter:image', content: siteLogo },
         // 移动端优化
         { name: 'theme-color', content: '#111111' },
         { name: 'apple-mobile-web-app-capable', content: 'yes' },
         { name: 'apple-mobile-web-app-status-bar-style', content: 'black-translucent' },
-        { name: 'apple-mobile-web-app-title', content: 'VoiceHub管理' },
+        { name: 'apple-mobile-web-app-title', content: siteShortName },
         { name: 'mobile-web-app-capable', content: 'yes' },
         { name: 'format-detection', content: 'telephone=no' }
       ],
@@ -287,9 +312,9 @@ export default defineNuxtConfig({
   pwa: {
     registerType: 'autoUpdate',
     manifest: {
-      name: 'VoiceHub',
-      short_name: 'VoiceHub',
-      description: '校园广播站点歌系统 - 让你的声音被听见',
+      name: siteTitle,
+      short_name: siteShortName,
+      description: siteDescription,
       theme_color: '#111111',
       background_color: '#111111',
       display: 'standalone',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,7 +4,7 @@ import glsl from 'vite-plugin-glsl'
 import { fileURLToPath } from 'url'
 
 // 解析自定义 SEO 和 PWA 配置
-let customSeoConfig: any = {}
+let customSeoConfig: { title?: string; shortName?: string; description?: string; logo?: string } = {}
 try {
   if (process.env.NUXT_PUBLIC_SEO_CONFIG) {
     customSeoConfig = JSON.parse(process.env.NUXT_PUBLIC_SEO_CONFIG)
@@ -14,7 +14,7 @@ try {
 }
 
 const siteTitle = customSeoConfig.title || process.env.NUXT_PUBLIC_SITE_TITLE || '校园广播站点歌系统'
-const siteShortName = customSeoConfig.shortName || process.env.NUXT_PUBLIC_SITE_TITLE || '校园广播'
+const siteShortName = customSeoConfig.shortName || '校园广播'
 const siteDescription = customSeoConfig.description || process.env.NUXT_PUBLIC_SITE_DESCRIPTION || '校园广播站点歌系统 - 让你的声音被听见'
 const siteLogo = customSeoConfig.logo || process.env.NUXT_PUBLIC_SITE_LOGO || '/images/logo.png'
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,6 +18,12 @@ const siteShortName = customSeoConfig.shortName || '校园广播'
 const siteDescription = customSeoConfig.description || process.env.NUXT_PUBLIC_SITE_DESCRIPTION || '校园广播站点歌系统 - 让你的声音被听见'
 const siteLogo = customSeoConfig.logo || process.env.NUXT_PUBLIC_SITE_LOGO || '/images/logo.png'
 
+// 构造绝对路径 Logo URL 用于 SEO 标签，如果没有 host，则回退为相对路径
+const host = process.env.NUXT_PUBLIC_HOST
+const absoluteLogo = (siteLogo.startsWith('http') || !host)
+  ? siteLogo
+  : `https://${host}${siteLogo.startsWith('/') ? '' : '/'}${siteLogo}`
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2026-01-30',
@@ -97,12 +103,12 @@ export default defineNuxtConfig({
         { property: 'og:title', content: siteTitle },
         { property: 'og:description', content: siteDescription },
         { property: 'og:site_name', content: siteTitle },
-        { property: 'og:image', content: siteLogo },
+        { property: 'og:image', content: absoluteLogo },
         // Twitter 标签
         { name: 'twitter:card', content: 'summary' },
         { name: 'twitter:title', content: siteTitle },
         { name: 'twitter:description', content: siteDescription },
-        { name: 'twitter:image', content: siteLogo },
+        { name: 'twitter:image', content: absoluteLogo },
         // 移动端优化
         { name: 'theme-color', content: '#111111' },
         { name: 'apple-mobile-web-app-capable', content: 'yes' },


### PR DESCRIPTION
- 解析 NUXT_PUBLIC_SEO_CONFIG 环境变量中的自定义配置
- 实现动态站点标题、描述、Logo 和短名称设置
- 添加 Open Graph 社交媒体标签支持
- 添加 Twitter 卡片标签优化
- 更新 PWA 清单文件使用动态配置
- 在 README 中添加新的环境变量文档说明

Closed #349 #350