### PR TITLE
refactor(songs): 优化撤回功能中的时间计算逻辑

### DIFF
--- a/server/api/songs/withdraw.post.ts
+++ b/server/api/songs/withdraw.post.ts
@@ -9,6 +9,12 @@ import {
   collaborationLogs
 } from '~/drizzle/schema'
 import { and, eq } from 'drizzle-orm'
+import {
+  getBeijingStartOfDay,
+  getBeijingEndOfDay,
+  getBeijingStartOfWeek,
+  getBeijingEndOfWeek
+} from '~/utils/timeUtils'
 
 export default defineEventHandler(async (event) => {
   // 检查用户认证
@@ -122,27 +128,19 @@ export default defineEventHandler(async (event) => {
 
   // 检查撤销的歌曲是否在当前限制期间内（用于返还配额）
   let canReturnQuota = false
-  const now = new Date()
 
   if (dailyLimit > 0) {
-    // 检查是否在同一天
-    const startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-    const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60 * 1000)
+    const startOfDay = getBeijingStartOfDay()
+    const endOfDay = getBeijingEndOfDay()
 
-    if (song.createdAt >= startOfDay && song.createdAt < endOfDay) {
+    if (song.createdAt >= startOfDay && song.createdAt <= endOfDay) {
       canReturnQuota = true
     }
   } else if (weeklyLimit > 0) {
-    // 检查是否在同一周（周一开始）
-    const startOfWeek = new Date(now)
-    const dayOfWeek = now.getDay()
-    const daysToSubtract = dayOfWeek === 0 ? 6 : dayOfWeek - 1 // 周一为一周开始
-    startOfWeek.setDate(now.getDate() - daysToSubtract)
-    startOfWeek.setHours(0, 0, 0, 0)
+    const startOfWeek = getBeijingStartOfWeek()
+    const endOfWeek = getBeijingEndOfWeek()
 
-    const endOfWeek = new Date(startOfWeek.getTime() + 7 * 24 * 60 * 60 * 1000)
-
-    if (song.createdAt >= startOfWeek && song.createdAt < endOfWeek) {
+    if (song.createdAt >= startOfWeek && song.createdAt <= endOfWeek) {
       canReturnQuota = true
     }
   }

--- a/server/api/songs/withdraw.post.ts
+++ b/server/api/songs/withdraw.post.ts
@@ -9,14 +9,7 @@ import {
   collaborationLogs
 } from '~/drizzle/schema'
 import { and, eq } from 'drizzle-orm'
-import {
-  getBeijingStartOfDay,
-  getBeijingEndOfDay,
-  getBeijingStartOfWeek,
-  getBeijingEndOfWeek,
-  getBeijingStartOfMonth,
-  getBeijingEndOfMonth
-} from '~/utils/timeUtils'
+import { getTimeRange, type LimitType } from '~~/server/utils/submissionLimit'
 
 export default defineEventHandler(async (event) => {
   // 检查用户认证
@@ -131,30 +124,19 @@ export default defineEventHandler(async (event) => {
   // 检查撤销的歌曲是否在当前限制期间内（用于返还配额）
   let canReturnQuota = false
 
-  if (dailyLimit > 0) {
-    const startOfDay = getBeijingStartOfDay()
-    const endOfDay = getBeijingEndOfDay()
+  const limitConfigs: { type: LimitType; value: number }[] = [
+    { type: 'daily', value: dailyLimit },
+    { type: 'weekly', value: weeklyLimit },
+    { type: 'monthly', value: monthlyLimit }
+  ]
 
-    if (song.createdAt >= startOfDay && song.createdAt <= endOfDay) {
-      canReturnQuota = true
-    }
-  }
-
-  if (!canReturnQuota && weeklyLimit > 0) {
-    const startOfWeek = getBeijingStartOfWeek()
-    const endOfWeek = getBeijingEndOfWeek()
-
-    if (song.createdAt >= startOfWeek && song.createdAt <= endOfWeek) {
-      canReturnQuota = true
-    }
-  }
-
-  if (!canReturnQuota && monthlyLimit > 0) {
-    const startOfMonth = getBeijingStartOfMonth()
-    const endOfMonth = getBeijingEndOfMonth()
-
-    if (song.createdAt >= startOfMonth && song.createdAt <= endOfMonth) {
-      canReturnQuota = true
+  for (const { type, value } of limitConfigs) {
+    if (value > 0) {
+      const { start, end } = getTimeRange(type)
+      if (song.createdAt >= start && song.createdAt <= end) {
+        canReturnQuota = true
+        break
+      }
     }
   }
 

--- a/server/api/songs/withdraw.post.ts
+++ b/server/api/songs/withdraw.post.ts
@@ -138,14 +138,18 @@ export default defineEventHandler(async (event) => {
     if (song.createdAt >= startOfDay && song.createdAt <= endOfDay) {
       canReturnQuota = true
     }
-  } else if (weeklyLimit > 0) {
+  }
+
+  if (!canReturnQuota && weeklyLimit > 0) {
     const startOfWeek = getBeijingStartOfWeek()
     const endOfWeek = getBeijingEndOfWeek()
 
     if (song.createdAt >= startOfWeek && song.createdAt <= endOfWeek) {
       canReturnQuota = true
     }
-  } else if (monthlyLimit > 0) {
+  }
+
+  if (!canReturnQuota && monthlyLimit > 0) {
     const startOfMonth = getBeijingStartOfMonth()
     const endOfMonth = getBeijingEndOfMonth()
 

--- a/server/api/songs/withdraw.post.ts
+++ b/server/api/songs/withdraw.post.ts
@@ -13,7 +13,9 @@ import {
   getBeijingStartOfDay,
   getBeijingEndOfDay,
   getBeijingStartOfWeek,
-  getBeijingEndOfWeek
+  getBeijingEndOfWeek,
+  getBeijingStartOfMonth,
+  getBeijingEndOfMonth
 } from '~/utils/timeUtils'
 
 export default defineEventHandler(async (event) => {
@@ -119,12 +121,12 @@ export default defineEventHandler(async (event) => {
   }
 
   // 如果是主投稿人撤回（删除歌曲）
-
   // 获取系统设置以检查限制类型
   const settingsResult = await db.select().from(systemSettings).limit(1)
   const settings = settingsResult[0]
   const dailyLimit = settings?.dailySubmissionLimit || 0
   const weeklyLimit = settings?.weeklySubmissionLimit || 0
+  const monthlyLimit = settings?.monthlySubmissionLimit || 0
 
   // 检查撤销的歌曲是否在当前限制期间内（用于返还配额）
   let canReturnQuota = false
@@ -141,6 +143,13 @@ export default defineEventHandler(async (event) => {
     const endOfWeek = getBeijingEndOfWeek()
 
     if (song.createdAt >= startOfWeek && song.createdAt <= endOfWeek) {
+      canReturnQuota = true
+    }
+  } else if (monthlyLimit > 0) {
+    const startOfMonth = getBeijingStartOfMonth()
+    const endOfMonth = getBeijingEndOfMonth()
+
+    if (song.createdAt >= startOfMonth && song.createdAt <= endOfMonth) {
       canReturnQuota = true
     }
   }


### PR DESCRIPTION
- 引入 Beijing 时间工具函数来处理日期时间计算
- 使用 getBeijingStartOfDay 和 getBeijingEndOfDay 替代手动日期计算
- 使用 getBeijingStartOfWeek 和 getBeijingEndOfWeek 替代手动周计算
- 修复时间范围比较逻辑，确保包含边界值
- 提高时间处理的一致性和可读性