### PR TITLE
fix(printer): 解决打印调度表时空容器残留问题

### DIFF
--- a/app/components/Admin/SchedulePrinter.vue
+++ b/app/components/Admin/SchedulePrinter.vue
@@ -905,6 +905,43 @@ const exportPDFForPrint = async (action = 'print') => {
 
     // 辅助：渲染当前页并添加到PDF
     const renderPage = async (isFirst) => {
+      // 在渲染前，清理页面中因为分页产生的空容器（如：没有子项的日期组、没有子项的表格），避免出现只有表头没有内容的孤立节点
+      const contentWrapper = pageContainer.querySelector('.schedule-content')
+      if (contentWrapper) {
+        const dGroups = contentWrapper.querySelectorAll('.date-group')
+        dGroups.forEach(dg => {
+          if (dg.querySelectorAll('.schedule-item').length === 0) {
+            dg.remove()
+          } else {
+            const ptGroups = dg.querySelectorAll('.playtime-group')
+            ptGroups.forEach(ptg => {
+              if (ptg.querySelectorAll('.schedule-item').length === 0) {
+                ptg.remove()
+              }
+            })
+            const ptWrappers = dg.querySelectorAll('.playtime-groups')
+            ptWrappers.forEach(ptw => {
+              if (ptw.children.length === 0) ptw.remove()
+            })
+          }
+        })
+
+        const tableWrappers = contentWrapper.querySelectorAll('.schedule-table-wrapper')
+        tableWrappers.forEach(wrapper => {
+          const table = wrapper.querySelector('.schedule-timetable')
+          if (table) {
+            let hasRows = false
+            const tbodies = table.querySelectorAll('tbody')
+            tbodies.forEach(tbody => {
+              if (tbody.querySelectorAll('tr').length > 0) hasRows = true
+            })
+            if (!hasRows) {
+              wrapper.remove()
+            }
+          }
+        })
+      }
+
       applyForceStyles(pageContainer)
 
       // 预处理当前页面的图片

--- a/app/components/Admin/SchedulePrinter.vue
+++ b/app/components/Admin/SchedulePrinter.vue
@@ -930,12 +930,14 @@ const exportPDFForPrint = async (action = 'print') => {
         tableWrappers.forEach(wrapper => {
           const table = wrapper.querySelector('.schedule-timetable')
           if (table) {
-            let hasRows = false
-            const tbodies = table.querySelectorAll('tbody')
-            tbodies.forEach(tbody => {
-              if (tbody.querySelectorAll('tr').length > 0) hasRows = true
+            // 移除没有歌曲项的 tbody (播放时间组)
+            table.querySelectorAll('tbody').forEach(tbody => {
+              if (tbody.querySelectorAll('.song-item').length === 0) {
+                tbody.remove()
+              }
             })
-            if (!hasRows) {
+            // 如果整个表格都没有歌曲项了，移除整个包装器
+            if (table.querySelectorAll('.song-item').length === 0) {
               wrapper.remove()
             }
           }


### PR DESCRIPTION
- 清理分页后产生的空日期组容器
- 移除没有子项的播放时间组容器
- 删除空的播放时间组包装器
- 过滤没有内容的表格包装器
- 避免打印时出现孤立的表头节点

Closed #298