### PR TITLE
fix(home): 修复首次访问引导加载逻辑

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -738,7 +738,7 @@ const bootProgress = ref(BOOT_PROGRESS.INITIAL)
 const bootMessage = ref(BOOT_MESSAGES.START)
 let bootSlowTimer = null
 
-let hasShownBootLoading = false
+const hasShownBootLoading = useState('hasShownBootLoading', () => false)
 
 const setBootState = ({ progress, message } = {}) => {
   if (typeof progress === 'number') {
@@ -1135,16 +1135,18 @@ watch(
   { immediate: true }
 )
 
-// 在组件挂载后初始化认证和歌曲（只会在客户端执行）
-onMounted(async () => {
-  const bootStartedAt = Date.now()
+const isFirstVisit = !hasShownBootLoading.value
 
-  const isFirstVisit = !hasShownBootLoading
-  hasShownBootLoading = true
-
+if (import.meta.client) {
   if (!isFirstVisit) {
     showBootLoading.value = false
   }
+  hasShownBootLoading.value = true
+}
+
+// 在组件挂载后初始化认证和歌曲（只会在客户端执行）
+onMounted(async () => {
+  const bootStartedAt = Date.now()
 
   try {
     if (isFirstVisit) {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -738,6 +738,8 @@ const bootProgress = ref(BOOT_PROGRESS.INITIAL)
 const bootMessage = ref(BOOT_MESSAGES.START)
 let bootSlowTimer = null
 
+let hasShownBootLoading = false
+
 const setBootState = ({ progress, message } = {}) => {
   if (typeof progress === 'number') {
     bootProgress.value = progress
@@ -1137,18 +1139,27 @@ watch(
 onMounted(async () => {
   const bootStartedAt = Date.now()
 
+  const isFirstVisit = !hasShownBootLoading
+  hasShownBootLoading = true
+
+  if (!isFirstVisit) {
+    showBootLoading.value = false
+  }
+
   try {
-    showBootLoading.value = true
-    setBootState({ progress: BOOT_PROGRESS.START })
+    if (isFirstVisit) {
+      showBootLoading.value = true
+      setBootState({ progress: BOOT_PROGRESS.START })
 
-    bootSlowTimer = setTimeout(() => {
-      setBootState({
-        progress: Math.max(bootProgress.value, BOOT_PROGRESS.SLOW_NETWORK),
-        message: BOOT_MESSAGES.SLOW_NETWORK
-      })
-    }, BOOT_SLOW_THRESHOLD_MS)
+      bootSlowTimer = setTimeout(() => {
+        setBootState({
+          progress: Math.max(bootProgress.value, BOOT_PROGRESS.SLOW_NETWORK),
+          message: BOOT_MESSAGES.SLOW_NETWORK
+        })
+      }, BOOT_SLOW_THRESHOLD_MS)
 
-    await waitForFirstPaint()
+      await waitForFirstPaint()
+    }
 
     setBootState({ progress: BOOT_PROGRESS.CONFIG, message: BOOT_MESSAGES.CONFIG })
     await initSiteConfig()
@@ -1218,16 +1229,20 @@ onMounted(async () => {
     }
   } catch (error) {
     console.error('首页初始化失败:', error)
-    setBootState({ progress: BOOT_PROGRESS.FALLBACK, message: BOOT_MESSAGES.FALLBACK })
+    if (isFirstVisit) {
+      setBootState({ progress: BOOT_PROGRESS.FALLBACK, message: BOOT_MESSAGES.FALLBACK })
+    }
     await Promise.allSettled([songs.fetchPublicSchedules(), songs.fetchSongCount()])
     await updateSongCounts()
   } finally {
-    if (bootSlowTimer) {
-      clearTimeout(bootSlowTimer)
-      bootSlowTimer = null
-    }
+    if (isFirstVisit) {
+      if (bootSlowTimer) {
+        clearTimeout(bootSlowTimer)
+        bootSlowTimer = null
+      }
 
-    await finishBootLoading(bootStartedAt)
+      await finishBootLoading(bootStartedAt)
+    }
   }
 })
 


### PR DESCRIPTION
- 添加 hasShownBootLoading 标志变量跟踪加载状态
- 区分首次访问和非首次访问的引导加载行为
- 非首次访问时跳过引导加载界面直接进入应用
- 首次访问时才显示引导加载进度和慢网络提示
- 异常处理和清理逻辑仅在首次访问时执行
- 优化引导流程避免重复显示加载界面