### PR TITLE
feat(sentry): 优化实例在线事务追踪功能

### DIFF
--- a/server/plugins/00.sentry.ts
+++ b/server/plugins/00.sentry.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/node'
 import type { H3Event } from 'h3'
-import { getInstanceId } from '../utils/instance-id'
+import { getInstanceIdInfo } from '../utils/instance-id'
 import { isTelemetryEnabled, isTelemetryEnabledCached } from '../utils/telemetry'
 
 declare global {
@@ -14,6 +14,8 @@ const getDeploymentTarget = (): string => {
   if (process.env.NITRO_PRESET?.includes('cloudflare')) return 'cloudflare'
   return 'self-hosted-node'
 }
+
+const INSTANCE_ONLINE_TRANSACTION = 'voicehub.instance.online'
 
 const shouldCaptureServerError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return true
@@ -44,6 +46,24 @@ const buildRequestContext = (event: H3Event) => {
   }
 }
 
+const captureInstanceOnlineTransaction = (instanceId: string, deploymentTarget: string) => {
+  Sentry.startSpan({
+    name: INSTANCE_ONLINE_TRANSACTION,
+    op: 'app.startup',
+    forceTransaction: true,
+    parentSpan: null,
+    attributes: {
+      'voicehub.event_type': 'instance_online',
+      'voicehub.instance_id': instanceId,
+      'deployment.target': deploymentTarget,
+      'runtime.name': 'nuxt',
+      'nitro.preset': process.env.NITRO_PRESET || 'node-server'
+    }
+  }, (span) => {
+    span.setAttribute('voicehub.instance_id', instanceId)
+  })
+}
+
 export default defineNitroPlugin((nitroApp) => {
   const config = useRuntimeConfig()
   const sentryConfig = config.sentry
@@ -68,12 +88,17 @@ export default defineNitroPlugin((nitroApp) => {
       }
 
       let instanceId = ''
+      let instanceIdPersisted = false
 
       try {
-        instanceId = await getInstanceId()
+        const instanceInfo = await getInstanceIdInfo()
+        instanceId = instanceInfo.instanceId
+        instanceIdPersisted = instanceInfo.persisted
       } catch (error) {
         console.warn('[Sentry] Failed to resolve instance ID for server tagging:', error)
       }
+
+      const deploymentTarget = getDeploymentTarget()
 
       Sentry.init({
         dsn: sentryConfig.dsn,
@@ -85,9 +110,16 @@ export default defineNitroPlugin((nitroApp) => {
           })
         ],
         enableLogs: true,
-        tracesSampleRate: sentryConfig.tracesSampleRate,
+        tracesSampler(samplingContext) {
+          return samplingContext.name === INSTANCE_ONLINE_TRANSACTION
+            ? 1
+            : sentryConfig.tracesSampleRate
+        },
         sendDefaultPii: false,
         beforeSend(event) {
+          return isTelemetryEnabledCached() ? event : null
+        },
+        beforeSendTransaction(event) {
           return isTelemetryEnabledCached() ? event : null
         }
       })
@@ -95,24 +127,22 @@ export default defineNitroPlugin((nitroApp) => {
       globalThis.__voicehubSentryServerInitialized = true
 
       Sentry.setTag('runtime', 'nuxt')
-      Sentry.setTag('deployment_target', getDeploymentTarget())
+      Sentry.setTag('deployment_target', deploymentTarget)
       Sentry.setTag('nitro_preset', process.env.NITRO_PRESET || 'node-server')
       if (instanceId) {
         Sentry.setTag('instance_id', instanceId)
+        Sentry.setTag('instance_id_persisted', String(instanceIdPersisted))
         Sentry.setContext('instance', {
-          instanceId
+          instanceId,
+          persisted: instanceIdPersisted
         })
       }
 
-      Sentry.withScope((scope) => {
-        scope.setLevel('info')
-        scope.setFingerprint(['instance_online', instanceId || 'unknown'])
-        scope.setTag('event_type', 'instance_online')
-        if (instanceId) {
-          scope.setTag('instance_id', instanceId)
-        }
-        Sentry.captureMessage('instance_online')
-      })
+      if (instanceIdPersisted && instanceId) {
+        captureInstanceOnlineTransaction(instanceId, deploymentTarget)
+      } else {
+        console.warn('[Sentry] Skipped instance startup transaction because instance ID was not persisted.')
+      }
 
       return true
     })().finally(() => {

--- a/server/plugins/00.sentry.ts
+++ b/server/plugins/00.sentry.ts
@@ -59,9 +59,7 @@ const captureInstanceOnlineTransaction = (instanceId: string, deploymentTarget: 
       'runtime.name': 'nuxt',
       'nitro.preset': process.env.NITRO_PRESET || 'node-server'
     }
-  }, (span) => {
-    span.setAttribute('voicehub.instance_id', instanceId)
-  })
+  }, () => {})
 }
 
 export default defineNitroPlugin((nitroApp) => {
@@ -113,7 +111,7 @@ export default defineNitroPlugin((nitroApp) => {
         tracesSampler(samplingContext) {
           return samplingContext.name === INSTANCE_ONLINE_TRANSACTION
             ? 1
-            : sentryConfig.tracesSampleRate
+            : samplingContext.inheritOrSampleWith(sentryConfig.tracesSampleRate)
         },
         sendDefaultPii: false,
         beforeSend(event) {

--- a/server/utils/instance-id.ts
+++ b/server/utils/instance-id.ts
@@ -64,8 +64,6 @@ const getCachedInstanceIdInfo = (): InstanceIdInfo | null => {
     return cachedInstanceIdInfo
   }
 
-  cachedInstanceIdInfo = null
-  cachedInstanceIdExpiresAt = 0
   return null
 }
 

--- a/server/utils/instance-id.ts
+++ b/server/utils/instance-id.ts
@@ -4,8 +4,17 @@ import { db } from '~/drizzle/db'
 import { systemSettings } from '~/drizzle/schema'
 import { SYSTEM_SETTINGS_DEFAULTS } from './system-settings-defaults'
 
-let cachedInstanceId: string | null = null
+export interface InstanceIdInfo {
+  instanceId: string
+  persisted: boolean
+}
+
+let cachedInstanceIdInfo: InstanceIdInfo | null = null
+let cachedInstanceIdExpiresAt = 0
 let pendingInstanceIdPromise: Promise<string> | null = null
+let pendingInstanceIdInfoPromise: Promise<InstanceIdInfo> | null = null
+
+const TEMPORARY_INSTANCE_ID_CACHE_TTL_MS = 5 * 60 * 1000
 
 const loadOrCreateInstanceId = async (): Promise<string> => {
   const settingsResult = await db
@@ -46,23 +55,57 @@ const loadOrCreateInstanceId = async (): Promise<string> => {
   return instanceId
 }
 
-export const getInstanceId = async (): Promise<string> => {
-  if (cachedInstanceId) {
-    return cachedInstanceId
+const getCachedInstanceIdInfo = (): InstanceIdInfo | null => {
+  if (!cachedInstanceIdInfo) {
+    return null
   }
 
-  if (!pendingInstanceIdPromise) {
-    pendingInstanceIdPromise = loadOrCreateInstanceId()
+  if (cachedInstanceIdInfo.persisted || cachedInstanceIdExpiresAt > Date.now()) {
+    return cachedInstanceIdInfo
+  }
+
+  cachedInstanceIdInfo = null
+  cachedInstanceIdExpiresAt = 0
+  return null
+}
+
+export const getInstanceIdInfo = async (): Promise<InstanceIdInfo> => {
+  const cached = getCachedInstanceIdInfo()
+  if (cached) {
+    return cached
+  }
+
+  if (!pendingInstanceIdInfoPromise) {
+    pendingInstanceIdInfoPromise = loadOrCreateInstanceId()
       .then((instanceId) => {
-        cachedInstanceId = instanceId
-        return instanceId
+        const info = { instanceId, persisted: true }
+        cachedInstanceIdInfo = info
+        cachedInstanceIdExpiresAt = Number.POSITIVE_INFINITY
+        return info
       })
       .catch((error) => {
-        // 使用备用 UUID 但不缓存为最终结果，允许下次调用时重试
-        const fallbackInstanceId = randomUUID()
+        const fallbackInstanceId = cachedInstanceIdInfo?.persisted === false
+          ? cachedInstanceIdInfo.instanceId
+          : randomUUID()
+
+        const info = { instanceId: fallbackInstanceId, persisted: false }
+        cachedInstanceIdInfo = info
+        cachedInstanceIdExpiresAt = Date.now() + TEMPORARY_INSTANCE_ID_CACHE_TTL_MS
         console.warn('[Instance ID] Failed to persist instance ID, using temporary fallback value:', error)
-        return fallbackInstanceId
+        return info
       })
+      .finally(() => {
+        pendingInstanceIdInfoPromise = null
+      })
+  }
+
+  return pendingInstanceIdInfoPromise
+}
+
+export const getInstanceId = async (): Promise<string> => {
+  if (!pendingInstanceIdPromise) {
+    pendingInstanceIdPromise = getInstanceIdInfo()
+      .then(({ instanceId }) => instanceId)
       .finally(() => {
         pendingInstanceIdPromise = null
       })


### PR DESCRIPTION
- 替换 getInstanceId 为 getInstanceIdInfo 函数以获取实例持久化状态
- 引入 INSTANCE_ONLINE_TRANSACTION 常量用于标识实例在线事务
- 实现 captureInstanceOnlineTransaction 函数用于记录实例启动事务
- 添加 tracesSampler 配置以确保实例在线事务始终被采样
- 扩展 InstanceIdInfo 接口包含实例ID和持久化状态信息
- 实现实例ID信息缓存机制支持临时ID和持久化ID区分
- 添加实例ID持久化状态标签到Sentry上下文中
- 仅在实例ID持久化时发送实例在线事务追踪数据