### PR TITLE
fix(admin): 修复歌曲下载对话框的预加载检查逻辑

### DIFF
--- a/app/components/Admin/SongDownloadDialog.vue
+++ b/app/components/Admin/SongDownloadDialog.vue
@@ -713,10 +713,11 @@ const preloadSelectedSongs = async () => {
 
   const songsToLoad = props.songs.filter(
     (s) => {
-      if (!selectedSongs.value.has(s.song.id)) return false
-      const cached = preloadedSongs.get(s.song.id)
+      const songId = s.song?.id
+      if (!songId || !selectedSongs.value.has(songId)) return false
+      const cached = preloadedSongs.get(songId)
       if (cached && cached.loading) return false
-      return !getUsablePreload(s.song.id, selectedQuality.value)
+      return !getUsablePreload(songId, selectedQuality.value)
     }
   )
 

--- a/app/components/Admin/SongDownloadDialog.vue
+++ b/app/components/Admin/SongDownloadDialog.vue
@@ -712,7 +712,12 @@ const preloadSelectedSongs = async () => {
   if (selectedSongs.value.size === 0) return
 
   const songsToLoad = props.songs.filter(
-    (s) => selectedSongs.value.has(s.song.id) && !getUsablePreload(s.song.id, selectedQuality.value)
+    (s) => {
+      if (!selectedSongs.value.has(s.song.id)) return false
+      const cached = preloadedSongs.get(s.song.id)
+      if (cached && cached.loading) return false
+      return !getUsablePreload(s.song.id, selectedQuality.value)
+    }
   )
 
   // 并发限制: 3


### PR DESCRIPTION
- 添加对已选歌曲的缓存状态检查
- 防止正在加载的歌曲重复加入下载队列
- 优化预加载判断条件避免冲突请求
- 确保只有未加载的歌曲才会被添加到下载列表