### PR TITLE
fix(frontend): 修复鸿蒙端播放器初始化偶发报错

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -187,6 +187,15 @@ export const useAuth = () => {
     }
   }
 
+  const getToken = () => {
+    // httpOnly cookie 模式下客户端不能读取真实 JWT，调用方应依赖同源 cookie。
+    if (token.value === 'cookie-based') {
+      return null
+    }
+
+    return token.value
+  }
+
   return {
     user,
     token,
@@ -200,6 +209,7 @@ export const useAuth = () => {
     setInitialPassword,
     refreshUser,
     initAuth,
+    getToken,
     getAuthConfig
   }
 }

--- a/app/composables/useProgressEvents.ts
+++ b/app/composables/useProgressEvents.ts
@@ -31,10 +31,14 @@ export const useProgressEvents = () => {
     startIndeterminate('正在连接...')
 
     try {
-      // 创建新的事件源，通过URL参数传递认证token
+      // cookie 认证下不能把真实 JWT 暴露到 URL，保留旧 token 参数仅作兼容。
       const auth = useAuth()
       const token = auth.getToken()
-      eventSource = new EventSource(`/api/progress/events?id=${id}&token=${token}`)
+      const params = new URLSearchParams({ id })
+      if (token) {
+        params.set('token', token)
+      }
+      eventSource = new EventSource(`/api/progress/events?${params.toString()}`)
 
       // 连接打开
       eventSource.onopen = () => {

--- a/app/composables/useProgressEvents.ts
+++ b/app/composables/useProgressEvents.ts
@@ -38,7 +38,9 @@ export const useProgressEvents = () => {
       if (token) {
         params.set('token', token)
       }
-      eventSource = new EventSource(`/api/progress/events?${params.toString()}`)
+      eventSource = new EventSource('/api/progress/events?' + params.toString(), {
+        withCredentials: true
+      })
 
       // 连接打开
       eventSource.onopen = () => {

--- a/server/api/progress/events.ts
+++ b/server/api/progress/events.ts
@@ -1,4 +1,4 @@
-import { createError, defineEventHandler, getQuery } from 'h3'
+import { createError, defineEventHandler, getCookie, getQuery } from 'h3'
 import jwt from 'jsonwebtoken'
 import { db } from '~/drizzle/db'
 
@@ -60,7 +60,7 @@ export default defineEventHandler(async (event) => {
   // 获取进度ID和token
   const query = getQuery(event)
   const id = query.id as string
-  const token = query.token as string
+  const token = (query.token as string) || getCookie(event, 'auth-token')
 
   if (!id) {
     throw createError({


### PR DESCRIPTION
- 为 useAuth 补回 getToken 兼容接口，避免旧调用方解构后调用空值
- cookie 认证模式下不再把占位 token 拼入 SSE URL
- 进度 SSE 服务端支持从 auth-token cookie 读取认证信息