### PR TITLE
feat(music): 实现QQ音乐播放链接解析功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,7 @@ VoiceHub/
 │   │   │   ├── bind.post.ts         # 绑定MeoW账号
 │   │   │   └── unbind.post.ts       # 解绑MeoW账号
 │   │   ├── music/          # 音乐相关API
+│   │   │   ├── resolve-url.post.ts # 音乐播放链接统一解析
 │   │   │   ├── state.post.ts        # 音乐状态管理
 │   │   │   └── websocket.ts         # 音乐WebSocket连接
 │   │   ├── native-api/     # 原生音乐API

--- a/README.md
+++ b/README.md
@@ -1842,8 +1842,10 @@ Thanks goes to these wonderful people:
 - [Sound-of-experiment - 实验之声广播站点歌系统](https://github.com/ljk743121/Sound-of-experiment) (哔哩哔哩音源搜索功能参考)
 - [Bilibili-audio-extraction](https://github.com/rio4raki/Bilibili-audio-extraction) (哔哩哔哩音频流获取参考)
 - [SPlayer](https://github.com/imsyy/SPlayer)
+- [Apple Music-like Lyrics](https://github.com/amll-dev/applemusic-like-lyrics)
 - [official-website - Sparkinit](https://github.com/Sparkinit/official-website)
 - [MusicAPI-rrvenn](https://music.rrvenn.cn)
+- [qq-music-api](https://github.com/sansenjian/qq-music-api) (QQ音乐歌词获取参考)
 
 ## 许可证
 

--- a/app/composables/useAudioPlayerSync.ts
+++ b/app/composables/useAudioPlayerSync.ts
@@ -319,7 +319,8 @@ export const useAudioPlayerSync = () => {
       if (platform === 'netease') {
         apiUrl = `https://api.vkeys.cn/v2/music/netease?id=${musicId}&quality=${quality}`
       } else if (platform === 'tencent') {
-        apiUrl = `https://api.vkeys.cn/v2/music/tencent?id=${musicId}&quality=${quality}`
+        const idParam = /^\d+$/.test(String(musicId)) ? `id=${musicId}` : `mid=${musicId}`
+        apiUrl = `https://api.vkeys.cn/v2/music/tencent?${idParam}&quality=${quality}`
       } else {
         return { success: false, error: '不支持的音乐平台' }
       }

--- a/app/composables/useMusicSources.ts
+++ b/app/composables/useMusicSources.ts
@@ -1405,10 +1405,17 @@ export const useMusicSources = () => {
       console.error('[getLyrics] 获取歌词失败:', error)
       return { success: false, error: error?.message || '未知错误' }
     }
-    })().finally(() => {
-      // 请求完成后延迟清除缓存，给并行请求复用窗口
-      setTimeout(() => {
+    })().then((res) => {
+      if (!res.success) {
+        // 失败立即清缓存，允许重试
         lyricCache.delete(cacheKey)
+      }
+      return res
+    }).finally(() => {
+      setTimeout(() => {
+        if (lyricCache.get(cacheKey) === promise) {
+          lyricCache.delete(cacheKey)
+        }
       }, LYRIC_CACHE_TTL)
     })
 

--- a/app/composables/useMusicSources.ts
+++ b/app/composables/useMusicSources.ts
@@ -270,10 +270,11 @@ export const useMusicSources = () => {
 
     try {
       // 优先尝试 Native Music 本地集成搜索 (仅支持网易云和QQ音乐)
-      // 只有当不是播客搜索时才使用
-      // 策略调整：如果服务器在中国，优先使用 Native Music；如果在海外，跳过 Native Music 直接使用第三方 API (除非第三方都失败)
+      // 策略调整：
+      // - QQ音乐平台：无论国内外均优先 Native Music
+      // - 网易云音乐平台：仅国内服务器优先 Native Music；海外跳过，直接使用第三方 API
       const platform = params.platform || 'netease'
-      const shouldUseNativeFirst = isServerInChina.value === true
+      const shouldUseNativeFirst = platform === 'tencent' || isServerInChina.value === true
 
       if (
         shouldUseNativeFirst &&
@@ -281,7 +282,10 @@ export const useMusicSources = () => {
         params.type !== 1009
       ) {
         try {
-          console.log(`[searchSongs] 服务器位于国内，优先尝试 Native Music 搜索...`)
+          const reason = platform === 'tencent'
+            ? '[searchSongs] QQ音乐平台，优先尝试 Native Music 搜索...'
+            : '[searchSongs] 服务器位于国内，优先尝试 Native Music 搜索...'
+          console.log(reason)
           const result = await searchNativeMusic(params)
           if (result && result.length > 0) {
             currentSource.value = 'native-music'

--- a/app/composables/useMusicSources.ts
+++ b/app/composables/useMusicSources.ts
@@ -6,6 +6,7 @@
 import {
   getEnabledSources,
   getSourceById,
+  getVkeysIdParam,
   MUSIC_SOURCE_CONFIG,
   type MusicSearchParams,
   type MusicSearchResult,
@@ -965,7 +966,8 @@ export const useMusicSources = () => {
                   ]
 
             for (const candidateQuality of qualityCandidates) {
-              const vkeysUrl = `${source.baseUrl}/${endpoint}?id=${idParam}&quality=${candidateQuality}`
+              const vkeysIdParam = getVkeysIdParam(endpoint as 'netease' | 'tencent', idParam)
+              const vkeysUrl = `${source.baseUrl}/${endpoint}?${vkeysIdParam.key}=${encodeURIComponent(vkeysIdParam.value)}&quality=${candidateQuality}`
               const vkeysResp = await $fetch(vkeysUrl, { timeout: source.timeout || 8000 })
 
               if (vkeysResp?.code === 200 && vkeysResp?.data?.url) {
@@ -976,7 +978,8 @@ export const useMusicSources = () => {
           } else if (source.id === 'vkeys-v3') {
             // Vkeys v3：先获取歌曲信息与音质列表，再按可用音质选择并调用 v2 获取可播放URL
             try {
-              const infoUrl = `${source.baseUrl}/tencent/song/info?id=${encodeURIComponent(idParam)}`
+              const v3IdParam = getVkeysIdParam('tencent', idParam)
+              const infoUrl = `${source.baseUrl}/tencent/song/info?${v3IdParam.key}=${encodeURIComponent(v3IdParam.value)}`
               const infoResp = await $fetch(infoUrl, { timeout: source.timeout || 8000 })
 
               // v3 成功码为 0
@@ -1039,7 +1042,8 @@ export const useMusicSources = () => {
                 throw new Error('未配置 vkeys v2 音源以获取播放链接')
               }
 
-              const v2Url = `${v2Source.baseUrl}/tencent?id=${idParam}&quality=${selectedQuality}`
+              const v2IdParam = getVkeysIdParam('tencent', idParam)
+              const v2Url = `${v2Source.baseUrl}/tencent?${v2IdParam.key}=${encodeURIComponent(v2IdParam.value)}&quality=${selectedQuality}`
               const v2Resp = await $fetch(v2Url, { timeout: v2Source.timeout || 8000 })
               if (v2Resp?.code === 200 && v2Resp?.data?.url) {
                 url = String(v2Resp.data.url)
@@ -1049,7 +1053,7 @@ export const useMusicSources = () => {
                   const hasQuality = qualityInfo.some((qi) => qi.type === q && Number(qi.size) > 0)
                   if (!hasQuality) continue
 
-                  const altUrl = `${v2Source.baseUrl}/tencent?id=${idParam}&quality=${q}`
+                  const altUrl = `${v2Source.baseUrl}/tencent?${v2IdParam.key}=${encodeURIComponent(v2IdParam.value)}&quality=${q}`
                   const altResp = await $fetch(altUrl, { timeout: v2Source.timeout || 8000 })
                   if (altResp?.code === 200 && altResp?.data?.url) {
                     url = String(altResp.data.url)
@@ -1249,10 +1253,11 @@ export const useMusicSources = () => {
 
         try {
           let url: string
+          const lyricIdParam = getVkeysIdParam(platform as 'netease' | 'tencent', id)
           if (platform === 'netease') {
-            url = `${vkeysSource.baseUrl}/netease/lyric?id=${id}`
+            url = `${vkeysSource.baseUrl}/netease/lyric?${lyricIdParam.key}=${encodeURIComponent(lyricIdParam.value)}`
           } else if (platform === 'tencent') {
-            url = `${vkeysSource.baseUrl}/tencent/lyric?id=${id}`
+            url = `${vkeysSource.baseUrl}/tencent/lyric?${lyricIdParam.key}=${encodeURIComponent(lyricIdParam.value)}`
           } else {
             return
           }

--- a/app/composables/useMusicSources.ts
+++ b/app/composables/useMusicSources.ts
@@ -17,6 +17,10 @@ import {
   type SourceStatus
 } from '~/utils/musicSources'
 import { getBilibiliTrackUrl, searchBilibili, parseBilibiliId } from '~/utils/bilibiliSource'
+
+// 歌词请求缓存，避免同一首歌重复请求
+const lyricCache = new Map<string, Promise<any>>()
+const LYRIC_CACHE_TTL = 60 * 1000
 /**
  * 音源管理器 Composable
  */
@@ -1186,7 +1190,16 @@ export const useMusicSources = () => {
     data?: { lrc: string; trans?: string; yrc?: string; ttml?: string }
     error?: string
   }> => {
-    try {
+    const cacheKey = `${platform}:${id}`
+
+    // 复用已缓存的请求结果
+    const cached = lyricCache.get(cacheKey)
+    if (cached) {
+      return cached
+    }
+
+    const promise = (async () => {
+      try {
       const settings = useLyricSettings()
       const enabledSources = getEnabledSources()
       const neteaseSource = enabledSources.find((source) => source.id.includes('netease-backup'))
@@ -1229,12 +1242,20 @@ export const useMusicSources = () => {
 
       // 辅助函数：获取 AMLL DB Server TTML
       const fetchAMLL = async () => {
-        if (platform !== 'netease' || !settings.enableOnlineTTMLLyric.value) return
-        const serverUrl = settings.amllDbServer.value
-        if (!serverUrl) return
+        if (!settings.enableOnlineTTMLLyric.value) return
 
         try {
-          const url = serverUrl.replace('%s', id.toString())
+          let url: string
+          if (platform === 'tencent') {
+            url = `https://amlldb.bikonoo.com/lyrics/qq-lyrics/${id}`
+          } else if (platform === 'netease') {
+            const serverUrl = settings.amllDbServer.value
+            if (!serverUrl) return
+            url = serverUrl.replace('%s', id.toString())
+          } else {
+            return
+          }
+
           const ttml = await $fetch(url, { responseType: 'text' })
           if (ttml && typeof ttml === 'string' && ttml.includes('<tt')) {
             resultData.ttml = ttml
@@ -1245,11 +1266,32 @@ export const useMusicSources = () => {
         }
       }
 
-      // 辅助函数：获取 QQ 音乐 (vkeys)
+      // 辅助函数：获取 QQ 音乐歌词（原生接口 + vkeys 兜底）
       const fetchQM = async () => {
-        if (!vkeysSource) return
         // 如果禁用了 QM 歌词且不是强制 QM 模式，则跳过
         if (!settings.enableQQMusicLyric.value && settings.lyricPriority.value !== 'qm') return
+
+        if (platform === 'tencent') {
+          try {
+            const nativeResp = await $fetch('/api/native-api/lyric/tx', {
+              params: { songmid: String(id) },
+              timeout: 8000
+            })
+            if (nativeResp?.success && nativeResp?.data) {
+              const d = nativeResp.data
+              if (d.lrc) resultData.lrc = d.lrc
+              if (d.trans) resultData.trans = d.trans
+              if (d.lrc) {
+                hasResult = true
+                return
+              }
+            }
+          } catch (e) {
+            console.warn('[getLyrics] 原生歌词接口失败:', e)
+          }
+        }
+
+        if (!vkeysSource) return
 
         try {
           let url: string
@@ -1285,9 +1327,11 @@ export const useMusicSources = () => {
       console.log(`[getLyrics] 使用策略: ${priority}, 平台: ${platform}, ID: ${id}`)
 
       if (priority === 'qm') {
+        // QQ 音乐优先：AMLL TTML → native 歌词 → vkeys 兜底
+        await fetchAMLL()
         await fetchQM()
         if (!hasResult) {
-          await Promise.all([fetchAMLL(), fetchOfficial()])
+          await Promise.all([fetchOfficial()])
         }
       } else if (priority === 'ttml') {
         await fetchAMLL()
@@ -1310,11 +1354,12 @@ export const useMusicSources = () => {
       } else if (priority === 'official') {
         await fetchOfficial()
       } else {
-        // auto / default
+        // auto / default：AMLL TTML 优先获取最高质量逐词歌词
+        await fetchAMLL()
         if (settings.enableQQMusicLyric.value) {
           await fetchQM()
         }
-        await Promise.all([fetchAMLL(), fetchOfficial()])
+        await fetchOfficial()
       }
 
       // 检查是否有结果
@@ -1360,6 +1405,15 @@ export const useMusicSources = () => {
       console.error('[getLyrics] 获取歌词失败:', error)
       return { success: false, error: error?.message || '未知错误' }
     }
+    })().finally(() => {
+      // 请求完成后延迟清除缓存，给并行请求复用窗口
+      setTimeout(() => {
+        lyricCache.delete(cacheKey)
+      }, LYRIC_CACHE_TTL)
+    })
+
+    lyricCache.set(cacheKey, promise)
+    return promise
   }
 
   /**

--- a/app/composables/useMusicSources.ts
+++ b/app/composables/useMusicSources.ts
@@ -197,12 +197,8 @@ export const useMusicSources = () => {
 
       return response.list.map((item: any) => {
         const isNetease = platform === 'netease'
-        // 统一使用 songmid 作为 ID
-        // 网易云: songmid 为数字 ID (e.g. 123456)
-        // QQ音乐: songmid 为字符串 MID (e.g. 004MmF3024567)，这对 vkeys 接口更友好
         const mid = item.songmid
-        // VoiceHub 内部 ID: 网易云使用数字ID，QQ音乐优先使用数字ID(songId)以便vkeys使用
-        const id = isNetease ? item.songmid : item.songId || item.songmid
+        const id = isNetease ? item.songmid : mid || item.songId
 
         return {
           id: id?.toString(),
@@ -217,10 +213,9 @@ export const useMusicSources = () => {
           url: undefined,
           hasUrl: false,
           sourceInfo: {
-            // 伪装源名称，以便兼容后续的播放逻辑
-            // 网易云使用 netease-backup，QQ音乐使用 vkeys
-            source: isNetease ? 'netease-backup' : 'vkeys',
+            source: isNetease ? 'netease-backup' : 'native-tx',
             originalId: id?.toString(),
+            originalSongId: !isNetease && item.songId ? item.songId.toString() : undefined,
             fetchedAt: new Date(),
             mid: mid,
             strMediaMid: item.strMediaMid, // Add strMediaMid
@@ -290,10 +285,7 @@ export const useMusicSources = () => {
           const result = await searchNativeMusic(params)
           if (result && result.length > 0) {
             currentSource.value = 'native-music'
-            // 这里不再将 lastUsedSource 设置为 'native-music'，
-            // 而是根据平台回退到能提供播放链接的音源ID（如 netease-backup 或 vkeys）。
-            // 这样 getSongUrl 等后续方法就会使用该音源进行播放链接获取。
-            lastUsedSource.value = platform === 'netease' ? 'netease-backup' : 'vkeys'
+            lastUsedSource.value = platform === 'netease' ? 'netease-backup' : 'qq-resolver'
             return {
               success: true,
               source: 'native-music',
@@ -1390,8 +1382,11 @@ export const useMusicSources = () => {
       console.log(`[transformVkeysResponse] QQ音乐处理 ${songs.length} 首歌曲`)
 
       return songs.map((song: any, index: number) => {
+        const mid = song.mid || song.songmid || song.songMID || song.musicId || song.id
+        const originalSongId =
+          song.id && song.id.toString() !== mid?.toString() ? song.id.toString() : undefined
         const transformedSong = {
-          id: song.id || song.musicId,
+          id: mid?.toString(),
           title: song.song || song.name || song.title,
           artist: song.singer || song.artist || '未知艺术家',
           cover: song.cover,
@@ -1399,14 +1394,15 @@ export const useMusicSources = () => {
           albumId: song.albumId,
           duration: song.duration || song.dt,
           musicPlatform: 'tencent',
-          musicId: (song.id || song.musicId)?.toString(),
+          musicId: mid?.toString(),
           url: song.url,
           hasUrl: !!song.url,
           sourceInfo: {
             source: 'vkeys',
-            originalId: (song.id || song.musicId)?.toString(),
+            originalId: mid?.toString(),
+            originalSongId,
             fetchedAt: new Date(),
-            mid: song.mid,
+            mid,
             vid: song.vid,
             quality: song.quality,
             pay: song.pay,
@@ -1476,10 +1472,12 @@ export const useMusicSources = () => {
     }
 
     return data.list.map((item: any) => {
-      const id = item.songID ?? item.songId ?? item.id
+      const mid = item.songMID ?? item.mid
+      const originalSongId = item.songID ?? item.songId ?? item.id
+      const id = mid ?? originalSongId
       const duration = item.interval ?? item.duration
       return {
-        id,
+        id: id?.toString(),
         title: item.title,
         artist: Array.isArray(item.singerList)
           ? item.singerList.map((s: any) => s.name).join('/')
@@ -1495,8 +1493,9 @@ export const useMusicSources = () => {
         sourceInfo: {
           source: 'vkeys-v3',
           originalId: id?.toString(),
+          originalSongId: originalSongId?.toString(),
           fetchedAt: new Date(),
-          mid: item.songMID || item.mid,
+          mid,
           vid: item.vid,
           quality: item.quality,
           pay: item.pay,

--- a/app/utils/musicSources.ts
+++ b/app/utils/musicSources.ts
@@ -227,3 +227,28 @@ export function getPrimarySource(): MusicSource | undefined {
 export function getBackupSources(): MusicSource[] {
   return getEnabledSources().filter((source) => source.id !== MUSIC_SOURCE_CONFIG.primarySource)
 }
+
+/**
+ * 判断是否为纯数字（旧版 QQ 音乐数字 id）
+ */
+function isNumericId(id: string | number): boolean {
+  return /^\d+$/.test(String(id))
+}
+
+/**
+ * 构造 vkeys 请求的身份参数
+ * 网易云始终用 id；QQ 音乐旧版数字 id 用 id，新版 mid 用 mid
+ */
+export function getVkeysIdParam(
+  platform: 'netease' | 'tencent',
+  musicId: string | number
+): { key: string; value: string } {
+  if (platform === 'netease') {
+    return { key: 'id', value: String(musicId) }
+  }
+  // tencent
+  if (isNumericId(musicId)) {
+    return { key: 'id', value: String(musicId) }
+  }
+  return { key: 'mid', value: String(musicId) }
+}

--- a/app/utils/musicUrl.ts
+++ b/app/utils/musicUrl.ts
@@ -75,7 +75,7 @@ export async function getMusicUrl(
       method: 'POST',
       body: {
         platform,
-        musicId: musicId.toString(),
+        musicId: String(musicId),
         quality,
         playUrl
       }

--- a/app/utils/musicUrl.ts
+++ b/app/utils/musicUrl.ts
@@ -1,5 +1,6 @@
 import { useAudioQuality } from '~/composables/useAudioQuality'
 import { useMusicSources } from '~/composables/useMusicSources'
+import { getVkeysIdParam } from '~/utils/musicSources'
 import { parseBilibiliId } from '~/utils/bilibiliSource'
 
 /**
@@ -116,7 +117,8 @@ export async function getMusicUrl(
   }
 
   for (const candidateQuality of qualityCandidates) {
-    const apiUrl = `https://api.vkeys.cn/v2/music/${endpoint}?id=${musicId}&quality=${candidateQuality}`
+    const idParam = getVkeysIdParam(endpoint as 'netease' | 'tencent', musicId)
+    const apiUrl = `https://api.vkeys.cn/v2/music/${endpoint}?${idParam.key}=${encodeURIComponent(idParam.value)}&quality=${candidateQuality}`
     const response = await fetch(apiUrl, {
       headers: {
         'User-Agent':

--- a/app/utils/musicUrl.ts
+++ b/app/utils/musicUrl.ts
@@ -34,11 +34,30 @@ export async function getMusicUrl(
   }
 
   const { getQuality } = useAudioQuality()
-  const { getSongUrl } = useMusicSources()
 
   // 优先使用 options 中的 quality，否则使用全局设置
   const quality =
     options?.quality !== undefined ? options.quality : getQuality(platform)
+
+  if (platform === 'tencent') {
+    const response: any = await $fetch('/api/music/resolve-url', {
+      method: 'POST',
+      body: {
+        platform,
+        musicId: musicId.toString(),
+        quality,
+        playUrl
+      }
+    })
+
+    if (response?.success && response?.url) {
+      return response.url
+    }
+
+    throw new Error(response?.message || 'QQ音乐播放链接解析失败')
+  }
+
+  const { getSongUrl } = useMusicSources()
   const isNeteasePlatform = platform === 'netease' || platform === 'netease-podcast'
   const hasNeteaseLogin =
     isNeteasePlatform &&

--- a/app/utils/musicUrl.ts
+++ b/app/utils/musicUrl.ts
@@ -41,6 +41,36 @@ export async function getMusicUrl(
     options?.quality !== undefined ? options.quality : getQuality(platform)
 
   if (platform === 'tencent') {
+    const normalizedQuality = Number(quality)
+    const qualityCandidates = [Number.isNaN(normalizedQuality) ? 8 : normalizedQuality]
+
+    for (const candidateQuality of qualityCandidates) {
+      const idParam = getVkeysIdParam('tencent', musicId)
+      const vkeysUrl = `https://api.vkeys.cn/v2/music/tencent?${idParam.key}=${encodeURIComponent(idParam.value)}&quality=${candidateQuality}`
+
+      try {
+        const vkeysResp = await fetch(vkeysUrl, {
+          headers: {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+          }
+        })
+
+        if (vkeysResp.ok) {
+          const data = await vkeysResp.json()
+          if (data.code === 200 && data.data && data.data.url) {
+            let url = data.data.url
+            if (url.startsWith('http://')) {
+              url = url.replace('http://', 'https://')
+            }
+            return url
+          }
+        }
+      } catch {
+        // vkeys 前端请求失败，继续走后端代理
+      }
+    }
+
+    // vkeys 前端失败，回退到后端 resolve-url
     const response: any = await $fetch('/api/music/resolve-url', {
       method: 'POST',
       body: {

--- a/app/utils/musicUrl.ts
+++ b/app/utils/musicUrl.ts
@@ -154,7 +154,8 @@ export async function getMusicUrl(
       headers: {
         'User-Agent':
           'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
-      }
+      },
+      signal: AbortSignal.timeout(5000)
     })
 
     if (!response.ok) {

--- a/app/utils/musicUrl.ts
+++ b/app/utils/musicUrl.ts
@@ -52,7 +52,8 @@ export async function getMusicUrl(
         const vkeysResp = await fetch(vkeysUrl, {
           headers: {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
-          }
+          },
+          signal: AbortSignal.timeout(5000)
         })
 
         if (vkeysResp.ok) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -363,7 +363,12 @@ export default defineNuxtConfig({
     plugins: [wasm(), topLevelAwait(), glsl()],
     optimizeDeps: {
       include: ['drizzle-orm'],
-      exclude: ['@applemusic-like-lyrics/vue', '@applemusic-like-lyrics/lyric']
+      exclude: [
+        '@applemusic-like-lyrics/vue',
+        '@applemusic-like-lyrics/lyric',
+        '#app-manifest',
+        'nuxt'
+      ]
     },
     build: {
       target: 'esnext',

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@applemusic-like-lyrics/lyric": "^0.3.0",
     "@applemusic-like-lyrics/vue": "^0.5.1",
     "@breezystack/lamejs": "^1.2.7",
-    "@neteasecloudmusicapienhanced/api": "^4.34.3",
+    "@neteasecloudmusicapienhanced/api": "^4.35.0",
     "@netlify/functions": "^2.8.2",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@pixi/app": "^7.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.2.7
         version: 1.2.7
       '@neteasecloudmusicapienhanced/api':
-        specifier: ^4.34.3
-        version: 4.34.3
+        specifier: ^4.35.0
+        version: 4.35.0
       '@netlify/functions':
         specifier: ^2.8.2
         version: 2.8.2
@@ -148,7 +148,7 @@ importers:
         version: 8.0.10
       nuxt:
         specifier: ^4.4.7
-        version: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9)))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9))(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0)
+        version: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.2)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9)))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9))(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0)
       otplib:
         specifier: ^12.0.1
         version: 12.0.1
@@ -175,13 +175,13 @@ importers:
         version: 4.22.4
       vite-plugin-glsl:
         specifier: ^1.6.0
-        version: 1.6.0(@rollup/pluginutils@5.4.0(rollup@4.61.1))(esbuild@0.27.7)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.6.0(@rollup/pluginutils@5.4.0(rollup@4.61.1))(esbuild@0.27.7)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(@swc/helpers@0.5.23)(rollup@4.61.1)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.6.0(@swc/helpers@0.5.23)(rollup@4.61.1)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
-        version: 3.6.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 3.6.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vue:
         specifier: ^3.5.35
         version: 3.5.35(typescript@6.0.3)
@@ -200,10 +200,10 @@ importers:
     devDependencies:
       '@nuxt/eslint':
         specifier: ^1.15.2
-        version: 1.15.2(@typescript-eslint/utils@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint@9.39.4(jiti@2.7.0))(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 1.15.2(@typescript-eslint/utils@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint@9.39.4(jiti@2.7.0))(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vite-pwa/nuxt':
         specifier: ^1.1.1
-        version: 1.1.1(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0)
+        version: 1.1.1(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -1621,8 +1621,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@neteasecloudmusicapienhanced/api@4.34.3':
-    resolution: {integrity: sha512-CF+5r+LRybwgoJXh/7eJAvYMcSjjZD4Q5Bdoe4V0HbaOsIXEkilvzs165WRlfo71otyANf/7/1ric/0KsapNvQ==}
+  '@neteasecloudmusicapienhanced/api@4.35.0':
+    resolution: {integrity: sha512-GdST0iLfexQWFfD9+/0Cgoa1VCanlS486dwxu7OsGfEK2lyq0lUsp6ltaGjRgJSJOlsYE6ue6U8F6ZE/X656Kw==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -3012,8 +3012,8 @@ packages:
   '@types/multer@2.1.0':
     resolution: {integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==}
 
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+  '@types/node@25.9.2':
+    resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
 
   '@types/nodemailer@8.0.0':
     resolution: {integrity: sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==}
@@ -3596,8 +3596,8 @@ packages:
       bare-events:
         optional: true
 
-  bare-url@2.4.3:
-    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
+  bare-url@2.4.5:
+    resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
 
   base64-arraybuffer@1.0.2:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
@@ -3606,8 +3606,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.33:
-    resolution: {integrity: sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==}
+  baseline-browser-mapping@2.10.34:
+    resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3753,8 +3753,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001793:
-    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+  caniuse-lite@1.0.30001797:
+    resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
 
   canvg@3.0.11:
     resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
@@ -4826,8 +4826,8 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  fuse.js@7.4.1:
-    resolution: {integrity: sha512-AY7lKAXK71hi3WgUvDy6oZL67UEHOOtvCAwVdOXHyJd6ZzftBy7QqxuXt4HxmmAhYjmp/YCuOELZtIvAdlZ+fw==}
+  fuse.js@7.4.2:
+    resolution: {integrity: sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==}
     engines: {node: '>=10'}
 
   fzf@0.5.2:
@@ -6871,8 +6871,8 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
-  streamx@2.26.0:
-    resolution: {integrity: sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==}
+  streamx@2.27.0:
+    resolution: {integrity: sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -6890,12 +6890,12 @@ packages:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
 
-  string.prototype.trim@1.2.10:
-    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+  string.prototype.trim@1.2.11:
+    resolution: {integrity: sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==}
     engines: {node: '>= 0.4'}
 
-  string.prototype.trimend@1.0.9:
-    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+  string.prototype.trimend@1.0.10:
+    resolution: {integrity: sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==}
     engines: {node: '>= 0.4'}
 
   string.prototype.trimstart@1.0.8:
@@ -7601,8 +7601,8 @@ packages:
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
-  which-typed-array@1.1.21:
-    resolution: {integrity: sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==}
+  which-typed-array@1.1.22:
+    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
     engines: {node: '>= 0.4'}
 
   which@2.0.2:
@@ -9120,7 +9120,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@neteasecloudmusicapienhanced/api@4.34.3':
+  '@neteasecloudmusicapienhanced/api@4.35.0':
     dependencies:
       '@neteasecloudmusicapienhanced/unblockmusic-utils': 0.3.2
       axios: 1.17.0
@@ -9188,7 +9188,7 @@ snapshots:
       debug: 4.4.3
       defu: 6.1.7
       exsolve: 1.0.8
-      fuse.js: 7.4.1
+      fuse.js: 7.4.2
       fzf: 0.5.2
       giget: 3.2.0
       jiti: 2.7.0
@@ -9217,11 +9217,11 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@3.2.4(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@nuxt/devtools-kit@3.2.4(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
       execa: 8.0.1
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - magicast
 
@@ -9236,9 +9236,9 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.8.2
 
-  '@nuxt/devtools@3.2.4(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
+  '@nuxt/devtools@3.2.4(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.2.4
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
       '@vue/devtools-core': 8.1.2(vue@3.5.35(typescript@6.0.3))
@@ -9266,9 +9266,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.0
       tinyglobby: 0.2.17
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-plugin-inspect: 11.4.1(@nuxt/kit@4.4.7(magicast@0.5.3))(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      vite-plugin-vue-tracer: 1.4.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-plugin-inspect: 11.4.1(@nuxt/kit@4.4.7(magicast@0.5.3))(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite-plugin-vue-tracer: 1.4.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       which: 6.0.1
       ws: 8.21.0
     transitivePeerDependencies:
@@ -9317,10 +9317,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.15.2(@typescript-eslint/utils@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint@9.39.4(jiti@2.7.0))(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@nuxt/eslint@1.15.2(@typescript-eslint/utils@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint@9.39.4(jiti@2.7.0))(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@eslint/config-inspector': 1.5.0(eslint@9.39.4(jiti@2.7.0))
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@nuxt/eslint-config': 1.15.2(@typescript-eslint/utils@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.5.35)(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@nuxt/eslint-plugin': 1.15.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
@@ -9396,7 +9396,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.7(6773d8de16698b76bd525457ea1e84a5)':
+  '@nuxt/nitro-server@4.4.7(6434bbcb2d4db645a820e011a6759aa9)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
@@ -9414,7 +9414,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9))(oxc-parser@0.133.0)(srvx@0.11.16)(xml2js@0.6.2)
-      nuxt: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9)))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9))(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0)
+      nuxt: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.2)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9)))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9))(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0)
       nypm: 0.6.6
       ohash: 2.0.11
       pathe: 2.0.3
@@ -9483,12 +9483,12 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/vite-builder@4.4.7(f7bb370a514b9e41fffd561fb778f955)':
+  '@nuxt/vite-builder@4.4.7(dce12d12a82ab50442ff85d1480a03dd)':
     dependencies:
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.61.1)
-      '@vitejs/plugin-vue': 6.0.7(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      '@vitejs/plugin-vue': 6.0.7(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       autoprefixer: 10.5.0(postcss@8.5.15)
       consola: 3.4.2
       cssnano: 8.0.1(postcss@8.5.15)
@@ -9501,7 +9501,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9)))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9))(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0)
+      nuxt: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.2)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9)))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9))(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0)
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -9510,9 +9510,9 @@ snapshots:
       std-env: 4.1.0
       ufo: 1.6.4
       unenv: 2.0.0-rc.24
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-node: 5.3.0(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-plugin-checker: 0.14.1(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-node: 5.3.0(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-plugin-checker: 0.14.1(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vue: 3.5.35(typescript@6.0.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -10498,11 +10498,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
 
   '@types/crypto-js@4.2.2': {}
 
@@ -10518,7 +10518,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -10538,7 +10538,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
 
   '@types/lodash-es@4.17.12':
     dependencies:
@@ -10552,19 +10552,19 @@ snapshots:
     dependencies:
       '@types/express': 5.0.6
 
-  '@types/node@25.9.1':
+  '@types/node@25.9.2':
     dependencies:
       undici-types: 7.24.6
 
   '@types/nodemailer@8.0.0':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
 
   '@types/pako@2.0.4': {}
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
       pg-protocol: 1.14.0
       pg-types: 2.2.0
 
@@ -10579,12 +10579,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
 
   '@types/trusted-types@2.0.7': {}
 
@@ -10787,12 +10787,12 @@ snapshots:
       vue: 3.5.35(typescript@6.0.3)
       vue-router: 4.6.4(vue@3.5.35(typescript@6.0.3))
 
-  '@vite-pwa/nuxt@1.1.1(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0)':
+  '@vite-pwa/nuxt@1.1.1(magicast@0.5.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0)':
     dependencies:
       '@nuxt/kit': 3.21.7(magicast@0.5.3)
       pathe: 1.1.2
       ufo: 1.6.4
-      vite-plugin-pwa: 1.3.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0)
+      vite-plugin-pwa: 1.3.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0)
     transitivePeerDependencies:
       - magicast
       - supports-color
@@ -10800,22 +10800,22 @@ snapshots:
       - workbox-build
       - workbox-window
 
-  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
+  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.1
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.7)
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.35(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.7(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.35(typescript@6.0.3)
 
   '@vue-macros/common@3.1.2(vue@3.5.35(typescript@6.0.3))':
@@ -11099,7 +11099,7 @@ snapshots:
   autoprefixer@10.5.0(postcss@8.5.15):
     dependencies:
       browserslist: 4.28.2
-      caniuse-lite: 1.0.30001793
+      caniuse-lite: 1.0.30001797
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.15
@@ -11156,7 +11156,7 @@ snapshots:
       bare-events: 2.9.1
       bare-path: 3.0.1
       bare-stream: 2.13.1(bare-events@2.9.1)
-      bare-url: 2.4.3
+      bare-url: 2.4.5
       fast-fifo: 1.3.2
     transitivePeerDependencies:
       - bare-abort-controller
@@ -11170,14 +11170,14 @@ snapshots:
 
   bare-stream@2.13.1(bare-events@2.9.1):
     dependencies:
-      streamx: 2.26.0
+      streamx: 2.27.0
       teex: 1.0.1
     optionalDependencies:
       bare-events: 2.9.1
     transitivePeerDependencies:
       - react-native-b4a
 
-  bare-url@2.4.3:
+  bare-url@2.4.5:
     dependencies:
       bare-path: 3.0.1
 
@@ -11186,7 +11186,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.33: {}
+  baseline-browser-mapping@2.10.34: {}
 
   basic-ftp@5.3.1: {}
 
@@ -11258,8 +11258,8 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.33
-      caniuse-lite: 1.0.30001793
+      baseline-browser-mapping: 2.10.34
+      caniuse-lite: 1.0.30001797
       electron-to-chromium: 1.5.368
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
@@ -11346,11 +11346,11 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.28.2
-      caniuse-lite: 1.0.30001793
+      caniuse-lite: 1.0.30001797
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001793: {}
+  caniuse-lite@1.0.30001797: {}
 
   canvg@3.0.11:
     dependencies:
@@ -11894,15 +11894,15 @@ snapshots:
       safe-regex-test: 1.1.0
       set-proto: 1.0.0
       stop-iteration-iterator: 1.1.0
-      string.prototype.trim: 1.2.10
-      string.prototype.trimend: 1.0.9
+      string.prototype.trim: 1.2.11
+      string.prototype.trimend: 1.0.10
       string.prototype.trimstart: 1.0.8
       typed-array-buffer: 1.0.3
       typed-array-byte-length: 1.0.3
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.8
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.21
+      which-typed-array: 1.1.22
 
   es-define-property@1.0.1: {}
 
@@ -12552,7 +12552,7 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  fuse.js@7.4.1: {}
+  fuse.js@7.4.2: {}
 
   fzf@0.5.2: {}
 
@@ -13013,7 +13013,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.21
+      which-typed-array: 1.1.22
 
   is-weakmap@2.0.2: {}
 
@@ -13620,16 +13620,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9)))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9))(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0):
+  nuxt@4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.2)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9)))(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(postgres@3.4.9))(eslint@9.39.4(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(sass@1.100.0)(srvx@0.11.16)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(xml2js@0.6.2)(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.7)(cac@6.7.14)(magicast@0.5.3)
-      '@nuxt/devtools': 3.2.4(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      '@nuxt/devtools': 3.2.4(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.7(6773d8de16698b76bd525457ea1e84a5)
+      '@nuxt/nitro-server': 4.4.7(6434bbcb2d4db645a820e011a6759aa9)
       '@nuxt/schema': 4.4.7
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.7(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.7(f7bb370a514b9e41fffd561fb778f955)
+      '@nuxt/vite-builder': 4.4.7(dce12d12a82ab50442ff85d1480a03dd)
       '@unhead/vue': 2.1.15(vue@3.5.35(typescript@6.0.3))
       '@vue/shared': 3.5.35
       chokidar: 5.0.0
@@ -13671,16 +13671,16 @@ snapshots:
       ultrahtml: 1.6.0
       uncrypto: 0.1.3
       unctx: 2.5.0
-      unhead: 3.1.3(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      unhead: 3.1.3(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       unimport: 6.3.0(oxc-parser@0.133.0)
       unplugin: 3.0.0
       unrouting: 0.1.7
       untyped: 2.0.0
       vue: 3.5.35(typescript@6.0.3)
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.35)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
+      vue-router: 5.1.0(@vue/compiler-sfc@3.5.35)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -14921,7 +14921,7 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
-  streamx@2.26.0:
+  streamx@2.27.0:
     dependencies:
       events-universal: 1.0.1
       fast-fifo: 1.3.2
@@ -14964,7 +14964,7 @@ snapshots:
       set-function-name: 2.0.2
       side-channel: 1.1.0
 
-  string.prototype.trim@1.2.10:
+  string.prototype.trim@1.2.11:
     dependencies:
       call-bind: 1.0.9
       call-bound: 1.0.4
@@ -14973,8 +14973,9 @@ snapshots:
       es-abstract: 1.24.2
       es-object-atoms: 1.1.2
       has-property-descriptors: 1.0.2
+      safe-regex-test: 1.1.0
 
-  string.prototype.trimend@1.0.9:
+  string.prototype.trimend@1.0.10:
     dependencies:
       call-bind: 1.0.9
       call-bound: 1.0.4
@@ -15121,7 +15122,7 @@ snapshots:
       b4a: 1.8.1
       bare-fs: 4.7.2
       fast-fifo: 1.3.2
-      streamx: 2.26.0
+      streamx: 2.27.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -15137,7 +15138,7 @@ snapshots:
 
   teex@1.0.1:
     dependencies:
-      streamx: 2.26.0
+      streamx: 2.27.0
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
@@ -15333,12 +15334,12 @@ snapshots:
     dependencies:
       hookable: 6.1.1
 
-  unhead@3.1.3(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  unhead@3.1.3(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       hookable: 6.1.1
       unplugin: 3.0.0
     optionalDependencies:
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -15520,23 +15521,23 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-dev-rpc@2.0.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-dev-rpc@2.0.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       birpc: 4.0.0
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-hot-client: 2.2.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-hot-client: 2.2.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  vite-hot-client@2.2.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-hot-client@2.2.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vite-node@5.3.0(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite-node@5.3.0(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.1.0
       obug: 2.1.2
       pathe: 2.0.3
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15550,7 +15551,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.14.1(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-plugin-checker@0.14.1(eslint@9.39.4(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -15559,20 +15560,20 @@ snapshots:
       picomatch: 4.0.4
       proper-lockfile: 4.1.2
       tiny-invariant: 1.3.3
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       eslint: 9.39.4(jiti@2.7.0)
       optionator: 0.9.4
       typescript: 6.0.3
 
-  vite-plugin-glsl@1.6.0(@rollup/pluginutils@5.4.0(rollup@4.61.1))(esbuild@0.27.7)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-plugin-glsl@1.6.0(@rollup/pluginutils@5.4.0(rollup@4.61.1))(esbuild@0.27.7)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
       esbuild: 0.27.7
 
-  vite-plugin-inspect@11.4.1(@nuxt/kit@4.4.7(magicast@0.5.3))(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-plugin-inspect@11.4.1(@nuxt/kit@4.4.7(magicast@0.5.3))(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       ansis: 4.3.1
       error-stack-parser-es: 1.0.5
@@ -15582,48 +15583,48 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-dev-rpc: 2.0.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-dev-rpc: 2.0.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@nuxt/kit': 4.4.7(magicast@0.5.3)
 
-  vite-plugin-pwa@1.3.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0):
+  vite-plugin-pwa@1.3.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.0)(workbox-window@7.4.0):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.17
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       workbox-build: 7.4.0
       workbox-window: 7.4.0
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-top-level-await@1.6.0(@swc/helpers@0.5.23)(rollup@4.61.1)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-plugin-top-level-await@1.6.0(@swc/helpers@0.5.23)(rollup@4.61.1)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.61.1)
       '@swc/core': 1.15.40(@swc/helpers@0.5.23)
       '@swc/wasm': 1.15.40
       uuid: 10.0.0
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
 
-  vite-plugin-vue-tracer@1.4.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3)):
+  vite-plugin-vue-tracer@1.4.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.35(typescript@6.0.3)
 
-  vite-plugin-wasm@3.6.0(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite-plugin-wasm@3.6.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -15632,7 +15633,7 @@ snapshots:
       rollup: 4.61.1
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
       fsevents: 2.3.3
       jiti: 2.7.0
       sass: 1.100.0
@@ -15663,7 +15664,7 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.35(typescript@6.0.3)
 
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.35)(vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3)):
+  vue-router@5.1.0(@vue/compiler-sfc@3.5.35)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.6
       '@vue-macros/common': 3.1.2(vue@3.5.35(typescript@6.0.3))
@@ -15685,7 +15686,7 @@ snapshots:
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.35
-      vite: 7.3.5(@types/node@25.9.1)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   vue@3.5.35(typescript@6.0.3):
     dependencies:
@@ -15740,7 +15741,7 @@ snapshots:
       isarray: 2.0.5
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
-      which-typed-array: 1.1.21
+      which-typed-array: 1.1.22
 
   which-collection@1.0.2:
     dependencies:
@@ -15751,7 +15752,7 @@ snapshots:
 
   which-module@2.0.1: {}
 
-  which-typed-array@1.1.21:
+  which-typed-array@1.1.22:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.9

--- a/server/api/music/resolve-url.post.ts
+++ b/server/api/music/resolve-url.post.ts
@@ -28,11 +28,6 @@ const normalizeTxQuality = (quality: unknown) => {
   return txQualityMap[key] || '320k'
 }
 
-const normalizeVkeysQuality = (quality: unknown) => {
-  const numericQuality = Number(quality)
-  return Number.isNaN(numericQuality) ? TX_MUSICU_FALLBACK_QUALITY : numericQuality
-}
-
 const resolveTxWithDreamMeting = async (songmid: string) => {
   const url = `https://music.3e0.cn/?server=tencent&type=url&id=${encodeURIComponent(songmid)}`
   const response = await fetch(url, {
@@ -76,27 +71,6 @@ const resolveTxWithHuibq = async (songmid: string, quality: string) => {
   return upgradeTxAudioUrl(data.url)
 }
 
-const resolveTxWithVkeys = async (musicId: string, quality: number) => {
-  const idParam = /^\d+$/.test(musicId) ? `id=${encodeURIComponent(musicId)}` : `mid=${encodeURIComponent(musicId)}`
-  const url = `https://api.vkeys.cn/v2/music/tencent?${idParam}&quality=${quality}`
-  const response = await fetch(url, {
-    headers: {
-      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
-    }
-  })
-
-  if (!response.ok) {
-    throw new Error(`vkeys 返回 ${response.status}`)
-  }
-
-  const data: any = await response.json()
-  if (data?.code !== 200 || !data?.data?.url) {
-    throw new Error(data?.message || data?.msg || 'vkeys 未返回播放链接')
-  }
-
-  return upgradeTxAudioUrl(data.data.url)
-}
-
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const platform = String(body?.platform || '').trim()
@@ -120,22 +94,9 @@ export default defineEventHandler(async (event) => {
   const normalized = normalizeTxMusicId(musicId)
   const playableInfo = await getTxSongPlayableInfo(musicId)
   const huibqQuality = normalizeTxQuality(body?.quality)
-  const vkeysQuality = normalizeVkeysQuality(body?.quality)
   const errors: string[] = []
 
-  try {
-    const url = await resolveTxWithDreamMeting(playableInfo.songmid)
-    return {
-      success: true,
-      url,
-      source: 'music.3e0.cn',
-      normalizedMusicId: playableInfo.songmid,
-      idType: normalized.idType
-    }
-  } catch (error: any) {
-    errors.push(`music.3e0.cn: ${error?.message || error}`)
-  }
-
+  // 优先尝试支持音质参数的源，确保用户选择的音质生效
   try {
     const url = await resolveTxWithHuibq(playableInfo.songmid, huibqQuality)
     return {
@@ -149,17 +110,18 @@ export default defineEventHandler(async (event) => {
     errors.push(`huibq: ${error?.message || error}`)
   }
 
+  // DreamMeting 不支持音质参数，作为最后的兜底
   try {
-    const url = await resolveTxWithVkeys(playableInfo.songId || playableInfo.songmid, vkeysQuality)
+    const url = await resolveTxWithDreamMeting(playableInfo.songmid)
     return {
       success: true,
       url,
-      source: 'vkeys',
+      source: 'music.3e0.cn',
       normalizedMusicId: playableInfo.songmid,
       idType: normalized.idType
     }
   } catch (error: any) {
-    errors.push(`vkeys: ${error?.message || error}`)
+    errors.push(`music.3e0.cn: ${error?.message || error}`)
   }
 
   throw createError({

--- a/server/api/music/resolve-url.post.ts
+++ b/server/api/music/resolve-url.post.ts
@@ -1,0 +1,168 @@
+import {
+  getTxSongPlayableInfo,
+  normalizeTxMusicId,
+  upgradeTxAudioUrl
+} from '~~/server/utils/native_tx'
+
+const TX_MUSICU_FALLBACK_QUALITY = 8
+const TX_DISABLED_EXPERIMENTAL_SOURCES = ['grass', 'flower']
+
+const txQualityMap: Record<string, string> = {
+  '4': '128k',
+  '8': '320k',
+  '10': 'flac',
+  '11': 'flac24bit',
+  '14': 'flac24bit',
+  '128': '128k',
+  '320': '320k',
+  '128k': '128k',
+  '320k': '320k',
+  flac: 'flac',
+  sq: 'flac',
+  hires: 'flac24bit',
+  flac24bit: 'flac24bit'
+}
+
+const normalizeTxQuality = (quality: unknown) => {
+  const key = String(quality ?? TX_MUSICU_FALLBACK_QUALITY).toLowerCase()
+  return txQualityMap[key] || '320k'
+}
+
+const normalizeVkeysQuality = (quality: unknown) => {
+  const numericQuality = Number(quality)
+  return Number.isNaN(numericQuality) ? TX_MUSICU_FALLBACK_QUALITY : numericQuality
+}
+
+const resolveTxWithDreamMeting = async (songmid: string) => {
+  const url = `https://music.3e0.cn/?server=tencent&type=url&id=${encodeURIComponent(songmid)}`
+  const response = await fetch(url, {
+    method: 'GET',
+    redirect: 'manual',
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+    }
+  })
+
+  const location = response.headers.get('location')
+  if (location) {
+    return upgradeTxAudioUrl(location)
+  }
+
+  if (response.redirected && response.url) {
+    return upgradeTxAudioUrl(response.url)
+  }
+
+  throw new Error(`music.3e0.cn 未返回播放重定向(${response.status})`)
+}
+
+const resolveTxWithHuibq = async (songmid: string, quality: string) => {
+  const url = `https://lxmusicapi.onrender.com/url/tx/${encodeURIComponent(songmid)}/${encodeURIComponent(quality)}`
+  const response = await fetch(url, {
+    headers: {
+      'X-Request-Key': 'share-v3',
+      'User-Agent': 'lx-music-desktop/2.11.0'
+    }
+  })
+
+  if (!response.ok) {
+    throw new Error(`Huibq 返回 ${response.status}`)
+  }
+
+  const data: any = await response.json()
+  if (data?.code !== 0 || !data?.url) {
+    throw new Error(data?.msg || data?.message || 'Huibq 未返回播放链接')
+  }
+
+  return upgradeTxAudioUrl(data.url)
+}
+
+const resolveTxWithVkeys = async (musicId: string, quality: number) => {
+  const url = `https://api.vkeys.cn/v2/music/tencent?id=${encodeURIComponent(musicId)}&quality=${quality}`
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+    }
+  })
+
+  if (!response.ok) {
+    throw new Error(`vkeys 返回 ${response.status}`)
+  }
+
+  const data: any = await response.json()
+  if (data?.code !== 200 || !data?.data?.url) {
+    throw new Error(data?.message || data?.msg || 'vkeys 未返回播放链接')
+  }
+
+  return upgradeTxAudioUrl(data.data.url)
+}
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const platform = String(body?.platform || '').trim()
+  const musicId = body?.musicId
+  const playUrl = String(body?.playUrl || '').trim()
+
+  if (playUrl) {
+    return {
+      success: true,
+      url: platform === 'tencent' ? upgradeTxAudioUrl(playUrl) : playUrl,
+      source: 'play-url',
+      normalizedMusicId: musicId ? String(musicId).trim() : '',
+      idType: 'provided-url'
+    }
+  }
+
+  if (platform !== 'tencent') {
+    throw createError({ statusCode: 400, message: '暂不支持的平台' })
+  }
+
+  const normalized = normalizeTxMusicId(musicId)
+  const playableInfo = await getTxSongPlayableInfo(musicId)
+  const huibqQuality = normalizeTxQuality(body?.quality)
+  const vkeysQuality = normalizeVkeysQuality(body?.quality)
+  const errors: string[] = []
+
+  try {
+    const url = await resolveTxWithDreamMeting(playableInfo.songmid)
+    return {
+      success: true,
+      url,
+      source: 'music.3e0.cn',
+      normalizedMusicId: playableInfo.songmid,
+      idType: normalized.idType
+    }
+  } catch (error: any) {
+    errors.push(`music.3e0.cn: ${error?.message || error}`)
+  }
+
+  try {
+    const url = await resolveTxWithHuibq(playableInfo.songmid, huibqQuality)
+    return {
+      success: true,
+      url,
+      source: 'huibq',
+      normalizedMusicId: playableInfo.songmid,
+      idType: normalized.idType
+    }
+  } catch (error: any) {
+    errors.push(`huibq: ${error?.message || error}`)
+  }
+
+  try {
+    const url = await resolveTxWithVkeys(playableInfo.songId || playableInfo.songmid, vkeysQuality)
+    return {
+      success: true,
+      url,
+      source: 'vkeys',
+      normalizedMusicId: playableInfo.songmid,
+      idType: normalized.idType
+    }
+  } catch (error: any) {
+    errors.push(`vkeys: ${error?.message || error}`)
+  }
+
+  throw createError({
+    statusCode: 502,
+    message: `QQ 音乐播放链接解析失败：${errors.join('；')}（实验源 ${TX_DISABLED_EXPERIMENTAL_SOURCES.join('/')} 默认禁用）`
+  })
+})

--- a/server/api/music/resolve-url.post.ts
+++ b/server/api/music/resolve-url.post.ts
@@ -77,7 +77,8 @@ const resolveTxWithHuibq = async (songmid: string, quality: string) => {
 }
 
 const resolveTxWithVkeys = async (musicId: string, quality: number) => {
-  const url = `https://api.vkeys.cn/v2/music/tencent?id=${encodeURIComponent(musicId)}&quality=${quality}`
+  const idParam = /^\d+$/.test(musicId) ? `id=${encodeURIComponent(musicId)}` : `mid=${encodeURIComponent(musicId)}`
+  const url = `https://api.vkeys.cn/v2/music/tencent?${idParam}&quality=${quality}`
   const response = await fetch(url, {
     headers: {
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'

--- a/server/api/music/resolve-url.post.ts
+++ b/server/api/music/resolve-url.post.ts
@@ -35,16 +35,13 @@ const resolveTxWithDreamMeting = async (songmid: string) => {
     redirect: 'manual',
     headers: {
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
-    }
+    },
+    signal: AbortSignal.timeout(5000)
   })
 
   const location = response.headers.get('location')
   if (location) {
     return upgradeTxAudioUrl(location)
-  }
-
-  if (response.redirected && response.url) {
-    return upgradeTxAudioUrl(response.url)
   }
 
   throw new Error(`music.3e0.cn 未返回播放重定向(${response.status})`)
@@ -56,7 +53,8 @@ const resolveTxWithHuibq = async (songmid: string, quality: string) => {
     headers: {
       'X-Request-Key': 'share-v3',
       'User-Agent': 'lx-music-desktop/2.11.0'
-    }
+    },
+    signal: AbortSignal.timeout(5000)
   })
 
   if (!response.ok) {

--- a/server/api/native-api/search/tx.get.ts
+++ b/server/api/native-api/search/tx.get.ts
@@ -15,14 +15,13 @@ export default defineEventHandler(async (event) => {
 
   let result: any
   try {
-    result = await txSignedRequest(body)
-  } catch (signedErr) {
-    console.warn('[tx.get] 签名请求失败，回退到普通请求:', signedErr)
-    // fallback 到普通 musicu.fcg 请求
-    result = await txRequest('https://u.y.qq.com/cgi-bin/musicu.fcg', body)
-  }
+    try {
+      result = await txSignedRequest(body)
+    } catch (signedErr) {
+      console.warn('[tx.get] 签名请求失败，回退到普通请求:', signedErr)
+      result = await txRequest('https://u.y.qq.com/cgi-bin/musicu.fcg', body)
+    }
 
-  try {
     if (result.code !== 0 || result.req?.code !== 0) {
       throw createError({ statusCode: 502, message: 'Tencent API Error' })
     }

--- a/server/api/native-api/search/tx.get.ts
+++ b/server/api/native-api/search/tx.get.ts
@@ -1,4 +1,4 @@
-import { createTxSearchBody, txRequest } from '../../../utils/native_tx'
+import { createTxSearchBody, txRequest, txSignedRequest } from '../../../utils/native_tx'
 import { decodeName, formatPlayTime, sizeFormate } from '../../../utils/native_common'
 
 export default defineEventHandler(async (event) => {
@@ -13,9 +13,16 @@ export default defineEventHandler(async (event) => {
 
   const body = createTxSearchBody(str, page, limit)
 
+  let result: any
   try {
-    const result: any = await txRequest('https://u.y.qq.com/cgi-bin/musicu.fcg', body)
+    result = await txSignedRequest(body)
+  } catch (signedErr) {
+    console.warn('[tx.get] 签名请求失败，回退到普通请求:', signedErr)
+    // fallback 到普通 musicu.fcg 请求
+    result = await txRequest('https://u.y.qq.com/cgi-bin/musicu.fcg', body)
+  }
 
+  try {
     if (result.code !== 0 || result.req?.code !== 0) {
       throw createError({ statusCode: 502, message: 'Tencent API Error' })
     }

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -42,6 +42,7 @@ export default defineEventHandler(async (event) => {
     '/api/system/location', // 系统位置检测API
     '/api/open/', // 开放API路径，由api-auth中间件处理认证
     '/api/auth/webauthn/login', // WebAuthn 登录接口
+    '/api/music/resolve-url', // 音乐播放链接解析
     '/api/music/state', // 音乐状态同步
     '/api/music/websocket', // WebSocket 连接
     '/api/sys/time' // 服务器时间同步

--- a/server/utils/native_tx.ts
+++ b/server/utils/native_tx.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto'
+
 export const txHeaders = {
   'User-Agent': 'QQMusic 14090508(android 12)'
 }
@@ -6,6 +8,54 @@ const TX_MUSICU_URL = 'https://u.y.qq.com/cgi-bin/musicu.fcg'
 const QQ_MID_PREFIX_RE = /^qqmid:/i
 const QQ_LEGACY_ID_RE = /^\d+$/
 const TX_DETAIL_CACHE_TTL = 6 * 60 * 60 * 1000
+
+// 签名算法常量
+const PART_1_INDEXES = [23, 14, 6, 36, 16, 40, 7, 19]
+const PART_2_INDEXES = [16, 1, 32, 12, 19, 27, 8, 5]
+const SCRAMBLE_VALUES = [89, 39, 179, 150, 218, 82, 58, 252, 177, 52, 186, 123, 120, 64, 242, 133, 143, 161, 121, 179]
+
+function pickHashByIdx(hash: string, indexes: number[]) {
+  return indexes.map((idx) => hash[idx]).join('')
+}
+
+function base64Encode(data: Buffer | string) {
+  return Buffer.from(data)
+    .toString('base64')
+    .replace(/[\\/+=]/g, '')
+}
+
+/**
+ * zzcSign 签名算法
+ * 模拟官方客户端签名，抗封锁能力更强
+ */
+export async function zzcSign(text: string) {
+  const hash = crypto.createHash('sha1').update(text).digest('hex')
+  const part1 = pickHashByIdx(hash, PART_1_INDEXES)
+  const part2 = pickHashByIdx(hash, PART_2_INDEXES)
+  const part3 = SCRAMBLE_VALUES.map((value, i) => value ^ parseInt(hash.slice(i * 2, i * 2 + 2), 16))
+  const b64Part = base64Encode(Buffer.from(part3)).replace(/[\\/+=]/g, '')
+  return `zzc${part1}${b64Part}${part2}`.toLowerCase()
+}
+
+/**
+ * 使用签名请求 QQ 音乐 API
+ * 相比普通 musicu.fcg，musics.fcg?sign=... 的签名请求更稳定
+ */
+export const txSignedRequest = async (body: any) => {
+  const sign = await zzcSign(JSON.stringify(body))
+  try {
+    const response = await $fetch(`https://u.y.qq.com/cgi-bin/musics.fcg?sign=${sign}`, {
+      method: 'POST',
+      headers: txHeaders,
+      body,
+      responseType: 'json'
+    })
+    return response
+  } catch (error) {
+    console.error('TX Signed Request Error:', error)
+    throw error
+  }
+}
 
 type TxIdType = 'legacy-id' | 'mid'
 

--- a/server/utils/native_tx.ts
+++ b/server/utils/native_tx.ts
@@ -2,6 +2,33 @@ export const txHeaders = {
   'User-Agent': 'QQMusic 14090508(android 12)'
 }
 
+const TX_MUSICU_URL = 'https://u.y.qq.com/cgi-bin/musicu.fcg'
+const QQ_MID_PREFIX_RE = /^qqmid:/i
+const QQ_LEGACY_ID_RE = /^\d+$/
+const TX_DETAIL_CACHE_TTL = 6 * 60 * 60 * 1000
+
+type TxIdType = 'legacy-id' | 'mid'
+
+interface TxNormalizedMusicId {
+  rawMusicId: string
+  normalizedMusicId: string
+  idType: TxIdType
+}
+
+interface TxSongPlayableInfo extends TxNormalizedMusicId {
+  songmid: string
+  songId?: string
+  strMediaMid?: string
+}
+
+const txSongDetailCache = new Map<
+  string,
+  {
+    expiresAt: number
+    value: TxSongPlayableInfo
+  }
+>()
+
 export const createTxSearchBody = (str: string, page: number, limit: number) => {
   return {
     comm: {
@@ -51,6 +78,111 @@ export const createTxSearchBody = (str: string, page: number, limit: number) => 
       }
     }
   }
+}
+
+export const normalizeTxMusicId = (musicId: string | number): TxNormalizedMusicId => {
+  const rawMusicId = String(musicId ?? '').trim()
+  const normalizedMusicId = rawMusicId.replace(QQ_MID_PREFIX_RE, '').trim()
+
+  if (!normalizedMusicId) {
+    throw createError({ statusCode: 400, message: '缺少 QQ 音乐ID' })
+  }
+
+  return {
+    rawMusicId,
+    normalizedMusicId,
+    idType: QQ_LEGACY_ID_RE.test(normalizedMusicId) ? 'legacy-id' : 'mid'
+  }
+}
+
+export const upgradeTxAudioUrl = (url: string) => {
+  return url.startsWith('http://') ? url.replace('http://', 'https://') : url
+}
+
+export const createTxSongDetailBody = (musicId: TxNormalizedMusicId) => {
+  const param =
+    musicId.idType === 'legacy-id'
+      ? { song_type: 0, song_id: Number(musicId.normalizedMusicId) }
+      : { song_type: 0, song_mid: musicId.normalizedMusicId }
+
+  return {
+    comm: {
+      ct: '19',
+      cv: '1859',
+      uin: '0'
+    },
+    req: {
+      module: 'music.pf_song_detail_svr',
+      method: 'get_song_detail_yqq',
+      param
+    }
+  }
+}
+
+const getCachedTxSongDetail = (key: string) => {
+  const cached = txSongDetailCache.get(key)
+  if (!cached) return null
+
+  if (cached.expiresAt <= Date.now()) {
+    txSongDetailCache.delete(key)
+    return null
+  }
+
+  return cached.value
+}
+
+const setCachedTxSongDetail = (key: string, value: TxSongPlayableInfo) => {
+  txSongDetailCache.set(key, {
+    expiresAt: Date.now() + TX_DETAIL_CACHE_TTL,
+    value
+  })
+}
+
+export const getTxSongPlayableInfo = async (
+  musicId: string | number
+): Promise<TxSongPlayableInfo> => {
+  const normalized = normalizeTxMusicId(musicId)
+  const cacheKey = `${normalized.idType}:${normalized.normalizedMusicId}`
+  const cached = getCachedTxSongDetail(cacheKey)
+  if (cached) return cached
+
+  if (normalized.idType === 'mid') {
+    const value = {
+      ...normalized,
+      songmid: normalized.normalizedMusicId
+    }
+    setCachedTxSongDetail(cacheKey, value)
+    return value
+  }
+
+  // 旧 QQ 数字 ID 只在播放时转 MID，避免批量改历史数据。
+  const result: any = await txRequest(TX_MUSICU_URL, createTxSongDetailBody(normalized))
+
+  if (result.code !== 0 || result.req?.code !== 0) {
+    throw createError({ statusCode: 502, message: 'QQ 音乐详情接口异常' })
+  }
+
+  const trackInfo = result.req?.data?.track_info
+  const songmid = trackInfo?.mid
+  if (!songmid) {
+    throw createError({ statusCode: 502, message: 'QQ 音乐详情缺少 MID' })
+  }
+
+  const value = {
+    ...normalized,
+    songmid,
+    songId: String(trackInfo.id || normalized.normalizedMusicId),
+    strMediaMid: trackInfo.file?.media_mid
+  }
+
+  setCachedTxSongDetail(cacheKey, value)
+  setCachedTxSongDetail(`mid:${songmid}`, {
+    ...value,
+    normalizedMusicId: songmid,
+    idType: 'mid'
+  })
+
+  return value
 }
 
 export const txRequest = async (url: string, body: any) => {

--- a/server/utils/native_tx.ts
+++ b/server/utils/native_tx.ts
@@ -41,17 +41,8 @@ export async function zzcSign(text: string) {
  * 使用签名请求 QQ 音乐 API
  * 相比普通 musicu.fcg，musics.fcg?sign=... 的签名请求更稳定
  */
-const canonicalize = (obj: any): any => {
-  if (obj === null || typeof obj !== 'object') return obj
-  if (Array.isArray(obj)) return obj.map(canonicalize)
-  return Object.keys(obj).sort().reduce((acc: any, key) => {
-    acc[key] = canonicalize(obj[key])
-    return acc
-  }, {})
-}
-
 export const txSignedRequest = async (body: any) => {
-  const sign = await zzcSign(JSON.stringify(canonicalize(body)))
+  const sign = await zzcSign(JSON.stringify(body))
   try {
     const response = await $fetch(`https://u.y.qq.com/cgi-bin/musics.fcg?sign=${sign}`, {
       method: 'POST',

--- a/server/utils/native_tx.ts
+++ b/server/utils/native_tx.ts
@@ -182,6 +182,12 @@ const getCachedTxSongDetail = (key: string) => {
 }
 
 const setCachedTxSongDetail = (key: string, value: TxSongPlayableInfo) => {
+  if (txSongDetailCache.size >= 1000) {
+    const firstKey = txSongDetailCache.keys().next().value
+    if (firstKey !== undefined) {
+      txSongDetailCache.delete(firstKey)
+    }
+  }
   txSongDetailCache.set(key, {
     expiresAt: Date.now() + TX_DETAIL_CACHE_TTL,
     value
@@ -208,7 +214,7 @@ export const getTxSongPlayableInfo = async (
   // 旧 QQ 数字 ID 只在播放时转 MID，避免批量改历史数据。
   const result: any = await txRequest(TX_MUSICU_URL, createTxSongDetailBody(normalized))
 
-  if (result.code !== 0 || result.req?.code !== 0) {
+  if (!result || result.code !== 0 || result.req?.code !== 0) {
     throw createError({ statusCode: 502, message: 'QQ 音乐详情接口异常' })
   }
 

--- a/server/utils/native_tx.ts
+++ b/server/utils/native_tx.ts
@@ -41,8 +41,17 @@ export async function zzcSign(text: string) {
  * 使用签名请求 QQ 音乐 API
  * 相比普通 musicu.fcg，musics.fcg?sign=... 的签名请求更稳定
  */
+const canonicalize = (obj: any): any => {
+  if (obj === null || typeof obj !== 'object') return obj
+  if (Array.isArray(obj)) return obj.map(canonicalize)
+  return Object.keys(obj).sort().reduce((acc: any, key) => {
+    acc[key] = canonicalize(obj[key])
+    return acc
+  }, {})
+}
+
 export const txSignedRequest = async (body: any) => {
-  const sign = await zzcSign(JSON.stringify(body))
+  const sign = await zzcSign(JSON.stringify(canonicalize(body)))
   try {
     const response = await $fetch(`https://u.y.qq.com/cgi-bin/musics.fcg?sign=${sign}`, {
       method: 'POST',


### PR DESCRIPTION
- 新增 resolve-url.post.ts API端点用于统一解析音乐播放链接
- 实现QQ音乐平台播放链接获取，支持多种第三方解析源
- 添加QQ音乐ID标准化和缓存机制，提升解析性能
- 集成多个QQ音乐解析服务商
- 重构音乐源处理逻辑，优化QQ音乐播放流程
- 更新依赖排除配置，调整构建优化设置