### PR TITLE
fix(audio): 修复QQ音乐无效音频链接检测逻辑

### DIFF
--- a/app/components/UI/AudioPlayer.vue
+++ b/app/components/UI/AudioPlayer.vue
@@ -213,6 +213,7 @@
           @ended="handleEnded"
           @error="handleError"
           @loadedmetadata="handleLoaded"
+          @durationchange="handleDurationChange"
           @loadstart="handleLoadStart"
           @pause="handlePause"
           @play="handlePlay"
@@ -683,6 +684,17 @@ const handlePause = () => {
     volume: 1,
     playlistIndex: sync.globalAudioPlayer.getCurrentPlaylistIndex().value
   })
+}
+
+const handleDurationChange = async () => {
+  if (!audioPlayer.value || isFallbackHandling.value) return
+
+  if (
+    isInvalidTencentAudio(audioPlayer.value.duration, audioPlayer.value.currentSrc || audioPlayer.value.src)
+  ) {
+    const switchedSource = await trySwitchPlaybackSource()
+    if (switchedSource) return
+  }
 }
 
 const handleLoaded = async () => {

--- a/app/utils/musicUrl.ts
+++ b/app/utils/musicUrl.ts
@@ -26,9 +26,7 @@ export type MusicUrlResolveResult = {
   idType?: string
 }
 
-export const INVALID_QQ_AUDIO_URLS = [
-  'https://panspace.kuwo.cn/2b7877721f6efffecd4abe8359325f29/6a2d0b00/resource/2149972737147268278.mp3'
-]
+export const INVALID_QQ_AUDIO_URL_SUFFIX = '/2149972737147268278.mp3'
 
 const musicUrlSourceCache = new Map<string, string>()
 
@@ -39,7 +37,7 @@ const normalizeCacheUrl = (url: string) => {
 export const isKnownInvalidQqAudioUrl = (url: string | null | undefined) => {
   if (!url) return false
   const normalizedUrl = normalizeCacheUrl(url)
-  return INVALID_QQ_AUDIO_URLS.includes(normalizedUrl)
+  return normalizedUrl.endsWith(INVALID_QQ_AUDIO_URL_SUFFIX)
 }
 
 const rememberMusicUrlSource = (url: string | null | undefined, source?: string) => {

--- a/app/utils/musicUrl.ts
+++ b/app/utils/musicUrl.ts
@@ -37,7 +37,8 @@ const normalizeCacheUrl = (url: string) => {
 export const isKnownInvalidQqAudioUrl = (url: string | null | undefined) => {
   if (!url) return false
   const normalizedUrl = normalizeCacheUrl(url)
-  return normalizedUrl.endsWith(INVALID_QQ_AUDIO_URL_SUFFIX)
+  const urlWithoutParams = normalizedUrl.split('?')[0].split('#')[0];
+  return urlWithoutParams.endsWith(INVALID_QQ_AUDIO_URL_SUFFIX)
 }
 
 const rememberMusicUrlSource = (url: string | null | undefined, source?: string) => {

--- a/server/api/music/resolve-url.post.ts
+++ b/server/api/music/resolve-url.post.ts
@@ -76,7 +76,8 @@ const resolveTxWithHuibq = async (songmid: string, quality: string) => {
 
 const validateResolvedTxUrl = (url: string, source: string) => {
   const normalizedUrl = upgradeTxAudioUrl(url.trim())
-  if (normalizedUrl.endsWith(INVALID_TX_AUDIO_URL_SUFFIX)) {
+  const urlWithoutParams = normalizedUrl.split('?')[0].split('#')[0];
+  if (urlWithoutParams.endsWith(INVALID_TX_AUDIO_URL_SUFFIX)) {
     throw new Error(`${source} 返回已知无效音频链接`)
   }
 

--- a/server/api/music/resolve-url.post.ts
+++ b/server/api/music/resolve-url.post.ts
@@ -10,9 +10,7 @@ import {
 
 const TX_MUSICU_FALLBACK_QUALITY = 8
 const TX_DISABLED_EXPERIMENTAL_SOURCES = ['grass', 'flower']
-const INVALID_TX_AUDIO_URLS = [
-  'https://panspace.kuwo.cn/2b7877721f6efffecd4abe8359325f29/6a2d0b00/resource/2149972737147268278.mp3'
-]
+const INVALID_TX_AUDIO_URL_SUFFIX = '/2149972737147268278.mp3'
 
 const txQualityMap: Record<string, string> = {
   '4': '128k',
@@ -78,7 +76,7 @@ const resolveTxWithHuibq = async (songmid: string, quality: string) => {
 
 const validateResolvedTxUrl = (url: string, source: string) => {
   const normalizedUrl = upgradeTxAudioUrl(url.trim())
-  if (INVALID_TX_AUDIO_URLS.includes(normalizedUrl)) {
+  if (normalizedUrl.endsWith(INVALID_TX_AUDIO_URL_SUFFIX)) {
     throw new Error(`${source} 返回已知无效音频链接`)
   }
 


### PR DESCRIPTION
- 在 AudioPlayer 组件中添加 durationchange 事件监听器
- 实现 handleDurationChange 方法处理音频时长变化
- 优化无效QQ音频检测逻辑，从完全匹配改为后缀匹配
- 移除硬编码的完整URL数组，改用后缀字符串进行检测
- 当检测到无效音频时自动尝试切换播放源

## Summary by Sourcery

Improve detection and handling of invalid QQ/Tencent music audio links in the player and backend validation.

Bug Fixes:
- Detect known invalid QQ audio responses by URL suffix instead of full URL match to avoid cache-related mismatches.
- Trigger invalid audio detection on audio duration changes and automatically attempt to switch to a fallback playback source when encountered.

Enhancements:
- Simplify invalid QQ/Tencent audio URL configuration by replacing hard-coded full URL lists with a shared suffix-based check used in both client and server validation.