### PR TITLE
feat(sentry): 添加外部音源错误过滤功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,7 @@ VoiceHub/
 │       ├── lyricAdapter.ts    # 歌词适配器
 │       ├── musicSources.ts    # 音乐源配置
 │       ├── musicUrl.ts        # 音乐URL处理
+│       ├── sentryUpstreamMusicErrors.ts # Sentry 上游音源错误过滤
 │       ├── neteaseApi.ts      # 网易云音乐API
 │       ├── oauth-register.ts  # OAuth注册工具
 │       ├── oauth.ts           # OAuth工具

--- a/app/plugins/sentry.client.ts
+++ b/app/plugins/sentry.client.ts
@@ -1,64 +1,36 @@
 import * as Sentry from '@sentry/vue'
 import type { Event, EventHint } from '@sentry/vue'
+import {
+  getSentryEventSearchText,
+  isExpectedUpstreamMusicError
+} from '~/utils/sentryUpstreamMusicErrors'
 
 let sentryClientInitialized = false
 let sentryClientInitializing = false
 let instanceId = ''
 const TELEMETRY_STORAGE_KEY = 'voicehub.telemetryEnabled'
-const EXPECTED_UPSTREAM_MUSIC_ERROR_PATTERNS = [
-  'QQ 音乐播放链接解析失败：',
-  '返回已知无效音频链接',
-  'music.3e0.cn 未返回播放重定向',
-  'Huibq 返回',
-  'Huibq 未返回播放链接',
-  'qq-music-api 未返回歌词',
-  '[tx.lyric] qq-music-api 歌词接口失败'
-]
 
-const stringifyErrorValue = (value: unknown): string => {
-  if (!value) return ''
-  if (typeof value === 'string') return value
-  if (value instanceof Error) return `${value.name}: ${value.message}`
-  if (typeof value !== 'object') return String(value)
-
-  const record = value as Record<string, unknown>
-  return [
-    record.message,
-    record.statusMessage,
-    record.statusCode,
-    stringifyErrorValue(record.cause)
-  ]
-    .filter((item) => item !== undefined && item !== null && item !== '')
-    .map(String)
-    .join(' ')
+const isTelemetryDisabledLocally = (): boolean => {
+  try {
+    return typeof localStorage !== 'undefined' &&
+      localStorage.getItem(TELEMETRY_STORAGE_KEY) === 'false'
+  } catch {
+    return false
+  }
 }
 
-const getSentryEventSearchText = (event: Event, hint?: EventHint): string => {
-  const exceptionTexts = event.exception?.values?.flatMap(value => [
-    value.type,
-    value.value
-  ]) || []
-
-  return [
-    event.message,
-    ...exceptionTexts,
-    stringifyErrorValue(hint?.originalException),
-    stringifyErrorValue(hint?.syntheticException)
-  ]
-    .filter((item) => item !== undefined && item !== null && item !== '')
-    .map(String)
-    .join('\n')
-}
-
-const isExpectedUpstreamMusicError = (text: string): boolean => {
-  const normalizedText = text.toLowerCase()
-  return EXPECTED_UPSTREAM_MUSIC_ERROR_PATTERNS.some((pattern) =>
-    normalizedText.includes(pattern.toLowerCase())
-  )
+const setTelemetryStorageValue = (value: string) => {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(TELEMETRY_STORAGE_KEY, value)
+    }
+  } catch {
+    // 隐私模式可能禁用 localStorage，遥测开关以服务端返回为准。
+  }
 }
 
 const shouldDropClientEvent = (event: Event, hint?: EventHint): boolean => {
-  if (typeof localStorage !== 'undefined' && localStorage.getItem(TELEMETRY_STORAGE_KEY) === 'false') {
+  if (isTelemetryDisabledLocally()) {
     return true
   }
 
@@ -114,11 +86,11 @@ export default defineNuxtPlugin((nuxtApp) => {
       }>('/api/system/instance')
 
       if (!response?.data?.telemetryEnabled) {
-        localStorage.setItem(TELEMETRY_STORAGE_KEY, 'false')
+        setTelemetryStorageValue('false')
         return
       }
 
-      localStorage.setItem(TELEMETRY_STORAGE_KEY, 'true')
+      setTelemetryStorageValue('true')
       instanceId = response.data.instanceId || ''
       console.log(`[VoiceHub] 遥测已开启，实例 ID: ${instanceId}（提交 Bug 时可提供此 ID 以便开发者定位）`)
 
@@ -172,7 +144,7 @@ export default defineNuxtPlugin((nuxtApp) => {
         Sentry.setContext('instance', { instanceId })
       }
     } catch (error) {
-      localStorage.setItem(TELEMETRY_STORAGE_KEY, 'false')
+      setTelemetryStorageValue('false')
       console.warn('[Sentry] Failed to initialize client telemetry:', error)
     } finally {
       sentryClientInitializing = false

--- a/app/plugins/sentry.client.ts
+++ b/app/plugins/sentry.client.ts
@@ -5,6 +5,57 @@ let sentryClientInitialized = false
 let sentryClientInitializing = false
 let instanceId = ''
 const TELEMETRY_STORAGE_KEY = 'voicehub.telemetryEnabled'
+const EXPECTED_UPSTREAM_MUSIC_ERROR_PATTERNS = [
+  'QQ 音乐播放链接解析失败：',
+  '返回已知无效音频链接',
+  'music.3e0.cn 未返回播放重定向',
+  'Huibq 返回',
+  'Huibq 未返回播放链接',
+  'qq-music-api 未返回歌词',
+  '[tx.lyric] qq-music-api 歌词接口失败'
+]
+
+const stringifyErrorValue = (value: unknown): string => {
+  if (!value) return ''
+  if (typeof value === 'string') return value
+  if (value instanceof Error) return `${value.name}: ${value.message}`
+  if (typeof value !== 'object') return String(value)
+
+  const record = value as Record<string, unknown>
+  return [
+    record.message,
+    record.statusMessage,
+    record.statusCode,
+    stringifyErrorValue(record.cause)
+  ]
+    .filter((item) => item !== undefined && item !== null && item !== '')
+    .map(String)
+    .join(' ')
+}
+
+const getSentryEventSearchText = (event: Event, hint?: EventHint): string => {
+  const exceptionTexts = event.exception?.values?.flatMap(value => [
+    value.type,
+    value.value
+  ]) || []
+
+  return [
+    event.message,
+    ...exceptionTexts,
+    stringifyErrorValue(hint?.originalException),
+    stringifyErrorValue(hint?.syntheticException)
+  ]
+    .filter((item) => item !== undefined && item !== null && item !== '')
+    .map(String)
+    .join('\n')
+}
+
+const isExpectedUpstreamMusicError = (text: string): boolean => {
+  const normalizedText = text.toLowerCase()
+  return EXPECTED_UPSTREAM_MUSIC_ERROR_PATTERNS.some((pattern) =>
+    normalizedText.includes(pattern.toLowerCase())
+  )
+}
 
 const shouldDropClientEvent = (event: Event, hint?: EventHint): boolean => {
   if (typeof localStorage !== 'undefined' && localStorage.getItem(TELEMETRY_STORAGE_KEY) === 'false') {
@@ -17,6 +68,11 @@ const shouldDropClientEvent = (event: Event, hint?: EventHint): boolean => {
   }
 
   if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return true
+  }
+
+  // 外部音源接口波动属于预期失败，本地交互提示即可。
+  if (isExpectedUpstreamMusicError(getSentryEventSearchText(event, hint))) {
     return true
   }
 
@@ -72,7 +128,10 @@ export default defineNuxtPlugin((nuxtApp) => {
           ? 'vercel'
           : 'self-hosted-node'
 
-      const integrations = [Sentry.browserTracingIntegration({ router: nuxtApp.$router })]
+      const sentryRouter = nuxtApp.$router as NonNullable<
+        Parameters<typeof Sentry.browserTracingIntegration>[0]
+      >['router']
+      const integrations = [Sentry.browserTracingIntegration({ router: sentryRouter })]
       integrations.push(
         Sentry.consoleLoggingIntegration({
           levels: import.meta.dev ? ['log', 'warn', 'error'] : ['error']

--- a/app/utils/sentryUpstreamMusicErrors.ts
+++ b/app/utils/sentryUpstreamMusicErrors.ts
@@ -1,0 +1,89 @@
+const MAX_ERROR_CAUSE_DEPTH = 3
+
+export const EXPECTED_UPSTREAM_MUSIC_ERROR_PATTERNS = [
+  'QQ 音乐播放链接解析失败：',
+  '返回已知无效音频链接',
+  'music.3e0.cn 未返回播放重定向',
+  'Huibq 返回',
+  'Huibq 未返回播放链接',
+  'qq-music-api 未返回歌词',
+  '[tx.lyric] qq-music-api 歌词接口失败'
+]
+
+type SentryLikeEvent = {
+  message?: unknown
+  exception?: {
+    values?: Array<{
+      type?: unknown
+      value?: unknown
+    }>
+  }
+  logentry?: {
+    message?: unknown
+    params?: unknown
+  }
+}
+
+type SentryLikeHint = {
+  originalException?: unknown
+  syntheticException?: unknown
+}
+
+export const stringifyErrorValue = (
+  value: unknown,
+  depth = 0,
+  seen = new WeakSet<object>()
+): string => {
+  if (!value || depth > MAX_ERROR_CAUSE_DEPTH) return ''
+  if (typeof value === 'string') return value
+  if (typeof value !== 'object') return String(value)
+
+  if (seen.has(value)) return ''
+  seen.add(value)
+
+  const record = value as Record<string, unknown>
+  const errorName = value instanceof Error ? value.name : record.name
+  const errorMessage = value instanceof Error ? value.message : record.message
+
+  return [
+    errorName,
+    errorMessage,
+    record.statusMessage,
+    record.statusCode,
+    stringifyErrorValue(record.cause, depth + 1, seen)
+  ]
+    .filter((item) => item !== undefined && item !== null && item !== '')
+    .map(String)
+    .join(' ')
+}
+
+export const getSentryEventSearchText = (
+  event: SentryLikeEvent,
+  hint?: SentryLikeHint
+): string => {
+  const exceptionValues = event.exception?.values || []
+  const exceptionTexts = exceptionValues.flatMap((value) => [
+    value.type,
+    value.value
+  ])
+  const logEntry = event.logentry || {}
+
+  return [
+    event.message,
+    logEntry.message,
+    ...(Array.isArray(logEntry.params) ? logEntry.params : []),
+    ...exceptionTexts,
+    stringifyErrorValue(hint?.originalException),
+    stringifyErrorValue(hint?.syntheticException)
+  ]
+    .filter((item) => item !== undefined && item !== null && item !== '')
+    .map(String)
+    .join('\n')
+}
+
+export const isExpectedUpstreamMusicError = (text: string): boolean => {
+  const normalizedText = text.toLowerCase()
+  return EXPECTED_UPSTREAM_MUSIC_ERROR_PATTERNS.some((pattern) =>
+    normalizedText.includes(pattern.toLowerCase())
+  )
+}

--- a/server/plugins/00.sentry.ts
+++ b/server/plugins/00.sentry.ts
@@ -16,6 +16,64 @@ const getDeploymentTarget = (): string => {
 }
 
 const INSTANCE_ONLINE_TRANSACTION = 'voicehub.instance.online'
+const EXPECTED_UPSTREAM_MUSIC_ERROR_PATTERNS = [
+  'QQ 音乐播放链接解析失败：',
+  '返回已知无效音频链接',
+  'music.3e0.cn 未返回播放重定向',
+  'Huibq 返回',
+  'Huibq 未返回播放链接',
+  'qq-music-api 未返回歌词',
+  '[tx.lyric] qq-music-api 歌词接口失败'
+]
+
+const stringifyErrorValue = (value: unknown): string => {
+  if (!value) return ''
+  if (typeof value === 'string') return value
+  if (value instanceof Error) return `${value.name}: ${value.message}`
+  if (typeof value !== 'object') return String(value)
+
+  const record = value as Record<string, unknown>
+  return [
+    record.message,
+    record.statusMessage,
+    record.statusCode,
+    stringifyErrorValue(record.cause)
+  ]
+    .filter((item) => item !== undefined && item !== null && item !== '')
+    .map(String)
+    .join(' ')
+}
+
+const getSentryEventSearchText = (
+  event: Record<string, any>,
+  hint?: Record<string, any>
+): string => {
+  const exceptionValues = event.exception?.values || []
+  const exceptionTexts = exceptionValues.flatMap((value: Record<string, unknown>) => [
+    value.type,
+    value.value
+  ])
+  const logEntry = event.logentry || {}
+
+  return [
+    event.message,
+    logEntry.message,
+    ...(Array.isArray(logEntry.params) ? logEntry.params : []),
+    ...exceptionTexts,
+    stringifyErrorValue(hint?.originalException),
+    stringifyErrorValue(hint?.syntheticException)
+  ]
+    .filter((item) => item !== undefined && item !== null && item !== '')
+    .map(String)
+    .join('\n')
+}
+
+const isExpectedUpstreamMusicError = (text: string): boolean => {
+  const normalizedText = text.toLowerCase()
+  return EXPECTED_UPSTREAM_MUSIC_ERROR_PATTERNS.some((pattern) =>
+    normalizedText.includes(pattern.toLowerCase())
+  )
+}
 
 const shouldCaptureServerError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return true
@@ -24,6 +82,11 @@ const shouldCaptureServerError = (error: unknown): boolean => {
 
   // Drop expected business/auth errors (4xx) to avoid Sentry noise.
   if (statusCode && statusCode >= 400 && statusCode < 500) {
+    return false
+  }
+
+  // 外部音源接口波动属于预期失败，本地保留日志和接口返回即可。
+  if (isExpectedUpstreamMusicError(stringifyErrorValue(error))) {
     return false
   }
 
@@ -125,8 +188,16 @@ export default defineNitroPlugin((nitroApp) => {
             : samplingContext.inheritOrSampleWith(sentryConfig.tracesSampleRate)
         },
         sendDefaultPii: false,
-        beforeSend(event) {
-          return isTelemetryEnabledCached() ? event : null
+        beforeSend(event, hint) {
+          if (!isTelemetryEnabledCached()) {
+            return null
+          }
+
+          if (isExpectedUpstreamMusicError(getSentryEventSearchText(event, hint))) {
+            return null
+          }
+
+          return event
         },
         beforeSendTransaction(event) {
           return isTelemetryEnabledCached() ? event : null

--- a/server/plugins/00.sentry.ts
+++ b/server/plugins/00.sentry.ts
@@ -1,5 +1,10 @@
 import * as Sentry from '@sentry/node'
 import type { H3Event } from 'h3'
+import {
+  getSentryEventSearchText,
+  isExpectedUpstreamMusicError,
+  stringifyErrorValue
+} from '~~/app/utils/sentryUpstreamMusicErrors'
 import { getInstanceIdInfo } from '../utils/instance-id'
 import { isTelemetryEnabled, isTelemetryEnabledCached } from '../utils/telemetry'
 
@@ -16,64 +21,6 @@ const getDeploymentTarget = (): string => {
 }
 
 const INSTANCE_ONLINE_TRANSACTION = 'voicehub.instance.online'
-const EXPECTED_UPSTREAM_MUSIC_ERROR_PATTERNS = [
-  'QQ 音乐播放链接解析失败：',
-  '返回已知无效音频链接',
-  'music.3e0.cn 未返回播放重定向',
-  'Huibq 返回',
-  'Huibq 未返回播放链接',
-  'qq-music-api 未返回歌词',
-  '[tx.lyric] qq-music-api 歌词接口失败'
-]
-
-const stringifyErrorValue = (value: unknown): string => {
-  if (!value) return ''
-  if (typeof value === 'string') return value
-  if (value instanceof Error) return `${value.name}: ${value.message}`
-  if (typeof value !== 'object') return String(value)
-
-  const record = value as Record<string, unknown>
-  return [
-    record.message,
-    record.statusMessage,
-    record.statusCode,
-    stringifyErrorValue(record.cause)
-  ]
-    .filter((item) => item !== undefined && item !== null && item !== '')
-    .map(String)
-    .join(' ')
-}
-
-const getSentryEventSearchText = (
-  event: Record<string, any>,
-  hint?: Record<string, any>
-): string => {
-  const exceptionValues = event.exception?.values || []
-  const exceptionTexts = exceptionValues.flatMap((value: Record<string, unknown>) => [
-    value.type,
-    value.value
-  ])
-  const logEntry = event.logentry || {}
-
-  return [
-    event.message,
-    logEntry.message,
-    ...(Array.isArray(logEntry.params) ? logEntry.params : []),
-    ...exceptionTexts,
-    stringifyErrorValue(hint?.originalException),
-    stringifyErrorValue(hint?.syntheticException)
-  ]
-    .filter((item) => item !== undefined && item !== null && item !== '')
-    .map(String)
-    .join('\n')
-}
-
-const isExpectedUpstreamMusicError = (text: string): boolean => {
-  const normalizedText = text.toLowerCase()
-  return EXPECTED_UPSTREAM_MUSIC_ERROR_PATTERNS.some((pattern) =>
-    normalizedText.includes(pattern.toLowerCase())
-  )
-}
 
 const shouldCaptureServerError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return true


### PR DESCRIPTION
- 定义了预期的上游音乐服务错误模式数组
- 实现了错误值字符串化函数用于提取错误信息
- 创建了 Sentry 事件搜索文本提取函数
- 添加了判断是否为预期上游音乐错误的检查函数
- 在服务端和客户端分别实现了错误过滤逻辑
- 避免将外部音源接口波动错误上报到 Sentry
- 更新了浏览器追踪集成以支持路由类型安全

## Summary by Sourcery

Add Sentry-based filtering for expected upstream music service errors on both server and client, and tighten browser tracing router typing.

New Features:
- Introduce pattern-based detection of expected upstream music service failures to exclude them from Sentry reporting on server and client.

Enhancements:
- Extract reusable utilities to stringify error values and derive searchable Sentry event text for filtering.
- Update browser tracing integration to use a type-safe router reference in the Sentry client plugin.