### PR TITLE
fix(migration): 解决数据库迁移脚本中的列重复添加问题

### DIFF
--- a/app/drizzle/migrations/20250913141519_clumsy_maria_hill.sql
+++ b/app/drizzle/migrations/20250913141519_clumsy_maria_hill.sql
@@ -1,10 +1,10 @@
-ALTER TABLE "SystemSettings" ADD COLUMN "smtpEnabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
-ALTER TABLE "SystemSettings" ADD COLUMN "smtpHost" text;--> statement-breakpoint
-ALTER TABLE "SystemSettings" ADD COLUMN "smtpPort" integer DEFAULT 587;--> statement-breakpoint
-ALTER TABLE "SystemSettings" ADD COLUMN "smtpSecure" boolean DEFAULT false;--> statement-breakpoint
-ALTER TABLE "SystemSettings" ADD COLUMN "smtpUsername" text;--> statement-breakpoint
-ALTER TABLE "SystemSettings" ADD COLUMN "smtpPassword" text;--> statement-breakpoint
-ALTER TABLE "SystemSettings" ADD COLUMN "smtpFromEmail" text;--> statement-breakpoint
-ALTER TABLE "SystemSettings" ADD COLUMN "smtpFromName" text DEFAULT '校园广播站';--> statement-breakpoint
-ALTER TABLE "User" ADD COLUMN "email" text;--> statement-breakpoint
-ALTER TABLE "User" ADD COLUMN "emailVerified" boolean DEFAULT false;
+ALTER TABLE "SystemSettings" ADD COLUMN IF NOT EXISTS "smtpEnabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "SystemSettings" ADD COLUMN IF NOT EXISTS "smtpHost" text;--> statement-breakpoint
+ALTER TABLE "SystemSettings" ADD COLUMN IF NOT EXISTS "smtpPort" integer DEFAULT 587;--> statement-breakpoint
+ALTER TABLE "SystemSettings" ADD COLUMN IF NOT EXISTS "smtpSecure" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "SystemSettings" ADD COLUMN IF NOT EXISTS "smtpUsername" text;--> statement-breakpoint
+ALTER TABLE "SystemSettings" ADD COLUMN IF NOT EXISTS "smtpPassword" text;--> statement-breakpoint
+ALTER TABLE "SystemSettings" ADD COLUMN IF NOT EXISTS "smtpFromEmail" text;--> statement-breakpoint
+ALTER TABLE "SystemSettings" ADD COLUMN IF NOT EXISTS "smtpFromName" text DEFAULT '校园广播站';--> statement-breakpoint
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "email" text;--> statement-breakpoint
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "emailVerified" boolean DEFAULT false;

--- a/app/drizzle/migrations/20251002085227_deep_silver_sable.sql
+++ b/app/drizzle/migrations/20251002085227_deep_silver_sable.sql
@@ -1,3 +1,3 @@
-ALTER TABLE "Schedule" ADD COLUMN "isDraft" boolean DEFAULT false NOT NULL;--> statement-breakpoint
-ALTER TABLE "Schedule" ADD COLUMN "publishedAt" timestamp;--> statement-breakpoint
-ALTER TABLE "Song" ADD COLUMN "playUrl" text;
+ALTER TABLE "Schedule" ADD COLUMN IF NOT EXISTS "isDraft" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "Schedule" ADD COLUMN IF NOT EXISTS "publishedAt" timestamp;--> statement-breakpoint
+ALTER TABLE "Song" ADD COLUMN IF NOT EXISTS "playUrl" text;


### PR DESCRIPTION
- 在 SystemSettings 表中为 smtp 相关字段添加 IF NOT EXISTS 条件
- 在 User 表中为 email 和 emailVerified 字段添加 IF NOT EXISTS 条件
- 在 Schedule 表中为 isDraft 和 publishedAt 字段添加 IF NOT EXISTS 条件
- 在 Song 表中为 playUrl 字段添加 IF NOT EXISTS 条件
- 防止在已存在列的情况下执行迁移导致的错误

## Summary by Sourcery

Guard existing database migrations against errors when columns are already present.

Bug Fixes:
- Add IF NOT EXISTS to smtp-related columns in SystemSettings to avoid duplicate column errors during migration re-runs.
- Add IF NOT EXISTS to email-related columns in User to prevent failures if columns already exist.
- Add IF NOT EXISTS to isDraft and publishedAt columns in Schedule to avoid re-adding existing columns.