### PR TITLE
feat(audio): 添加网易云音乐听歌打卡功能

### DIFF
--- a/app/components/Songs/PlaylistSelectionModal.vue
+++ b/app/components/Songs/PlaylistSelectionModal.vue
@@ -520,10 +520,12 @@ const playSong = (songData) => {
     title: songData.name,
     artist: songData.ar?.map((a) => a.name).join('/'),
     cover: songData.al?.picUrl,
+    albumId: songData.al?.id,
     musicPlatform: 'netease',
     musicId: songData.id.toString(),
     sourceInfo: {
       source: 'netease-backup',
+      playlistId: selectedPlaylist.value?.id,
       type: 'song'
     }
   })
@@ -539,11 +541,13 @@ const selectSong = (songData) => {
     artist: songData.ar?.map((a) => a.name).join('/'),
     cover: songData.al?.picUrl,
     album: songData.al?.name,
+    albumId: songData.al?.id,
     duration: songData.dt,
     musicPlatform: 'netease',
     musicId: songData.id.toString(),
     sourceInfo: {
       source: 'netease-backup',
+      playlistId: selectedPlaylist.value?.id,
       type: 'song'
     }
   }

--- a/app/components/Songs/RecentSongsModal.vue
+++ b/app/components/Songs/RecentSongsModal.vue
@@ -386,6 +386,7 @@ const playSong = (songData) => {
     title: songData.name,
     artist: songData.ar?.map((a) => a.name).join('/'),
     cover: songData.al?.picUrl,
+    albumId: songData.al?.id,
     musicPlatform: 'netease',
     musicId: songData.id.toString(),
     sourceInfo: {
@@ -405,6 +406,7 @@ const selectSong = (songData) => {
     artist: songData.ar?.map((a) => a.name).join('/'),
     cover: songData.al?.picUrl,
     album: songData.al?.name,
+    albumId: songData.al?.id,
     duration: songData.dt,
     musicPlatform: 'netease',
     musicId: songData.id.toString(),

--- a/app/components/Songs/RequestForm.vue
+++ b/app/components/Songs/RequestForm.vue
@@ -2857,6 +2857,8 @@ const playSong = async (result, playlist, playlistIndex) => {
     musicUrl: result.url || null, // 哔哩哔哩可能没有音频URL
     musicPlatform: result.musicPlatform || platform.value,
     musicId: finalMusicId,
+    albumId: result.albumId,
+    sourceInfo: result.sourceInfo,
     bilibiliCid: result.bilibiliCid // 确保传递 cid
   }
 

--- a/app/components/UI/AudioPlayer.vue
+++ b/app/components/UI/AudioPlayer.vue
@@ -330,9 +330,11 @@ const MAX_CONSECUTIVE_SKIP = 3 // 最大连续跳过次数
 const MIN_VALID_QQ_AUDIO_DURATION = 10
 const NETEASE_SCROBBLE_MIN_SECONDS = 30
 const NETEASE_SCROBBLE_SHORT_AUDIO_RATIO = 0.8
+const MAX_NETEASE_SCROBBLE_RETRIES = 3
 const failedPlaybackSources = ref<string[]>([])
 const neteaseScrobbleReportedKey = ref<string | null>(null)
 const neteaseScrobblePendingKey = ref<string | null>(null)
+const neteaseScrobbleRetryCount = ref(0)
 
 // 获取音频播放器引用
 const audioPlayer = computed(() => audioElementRef.value?.audioPlayer)
@@ -470,6 +472,7 @@ watch(
       failedPlaybackSources.value = []
       neteaseScrobbleReportedKey.value = null
       neteaseScrobblePendingKey.value = null
+      neteaseScrobbleRetryCount.value = 0
       enhanced.resetRetryState()
     }
   }
@@ -633,15 +636,12 @@ const getNeteaseScrobbleThreshold = (durationValue) => {
   )
 }
 
-const tryScrobbleNeteaseSong = async (currentTimeValue, durationValue) => {
-  if (!control.isPlaying.value || typeof window === 'undefined') return
+const tryScrobbleNeteaseSong = async (currentTimeValue, durationValue, isEnded = false) => {
+  if ((!control.isPlaying.value && !isEnded) || typeof window === 'undefined') return
 
   const song = activeSong.value
   const songId = getNeteaseScrobbleSongId(song)
   if (!songId) return
-
-  const cookie = window.localStorage.getItem('netease_cookie')
-  if (!cookie) return
 
   const threshold = getNeteaseScrobbleThreshold(durationValue)
   if (currentTimeValue < threshold) return
@@ -650,12 +650,17 @@ const tryScrobbleNeteaseSong = async (currentTimeValue, durationValue) => {
   const scrobbleKey = `${songId}:${sourceId}`
   if (
     neteaseScrobbleReportedKey.value === scrobbleKey ||
-    neteaseScrobblePendingKey.value === scrobbleKey
+    neteaseScrobblePendingKey.value === scrobbleKey ||
+    neteaseScrobbleRetryCount.value >= MAX_NETEASE_SCROBBLE_RETRIES
   ) {
     return
   }
 
+  const cookie = window.localStorage.getItem('netease_cookie')
+  if (!cookie) return
+
   neteaseScrobblePendingKey.value = scrobbleKey
+  neteaseScrobbleRetryCount.value++
   try {
     const playTime = Math.max(
       1,
@@ -992,7 +997,11 @@ const handleError = async (error) => {
 
 const handleEnded = () => {
   if (audioPlayer.value) {
-    void tryScrobbleNeteaseSong(audioPlayer.value.duration || control.currentTime.value, audioPlayer.value.duration)
+    void tryScrobbleNeteaseSong(
+      audioPlayer.value.duration || control.currentTime.value,
+      audioPlayer.value.duration,
+      true
+    )
   }
 
   // 在执行 onEnded（可能会切换到下一首）之前，记录当前是否还有下一首

--- a/app/components/UI/AudioPlayer.vue
+++ b/app/components/UI/AudioPlayer.vue
@@ -265,6 +265,7 @@ import { useAudioQuality } from '~/composables/useAudioQuality'
 import { useAudioPlayerEnhanced } from '~/composables/useAudioPlayerEnhanced'
 import { useMediaSession } from '~/composables/useMediaSession'
 import { getBilibiliUrl } from '~/utils/url'
+import { scrobbleSong } from '~/utils/neteaseApi'
 import { isBilibiliSong } from '~/utils/bilibiliSource'
 import {
   getCachedMusicUrlSource,
@@ -327,7 +328,11 @@ const isFallbackHandling = ref(false) // 标记正在处理 fallback，阻止重
 const consecutiveSkipCount = ref(0) // 连续跳过失败的歌曲数
 const MAX_CONSECUTIVE_SKIP = 3 // 最大连续跳过次数
 const MIN_VALID_QQ_AUDIO_DURATION = 10
+const NETEASE_SCROBBLE_MIN_SECONDS = 30
+const NETEASE_SCROBBLE_SHORT_AUDIO_RATIO = 0.8
 const failedPlaybackSources = ref<string[]>([])
+const neteaseScrobbleReportedKey = ref<string | null>(null)
+const neteaseScrobblePendingKey = ref<string | null>(null)
 
 // 获取音频播放器引用
 const audioPlayer = computed(() => audioElementRef.value?.audioPlayer)
@@ -463,6 +468,8 @@ watch(
       lastOpenedFallbackSongId.value = null
       isFallbackHandling.value = false
       failedPlaybackSources.value = []
+      neteaseScrobbleReportedKey.value = null
+      neteaseScrobblePendingKey.value = null
       enhanced.resetRetryState()
     }
   }
@@ -596,6 +603,88 @@ const isInvalidTencentAudio = (duration, url) => {
   return isKnownInvalidQqAudioUrl(url)
 }
 
+const getNeteaseScrobbleSongId = (song) => {
+  if (!song || song.musicPlatform !== 'netease') return null
+  if (song.sourceInfo?.type === 'voice') return null
+
+  const rawId = String(song.musicId || song.id || '').trim()
+  if (!/^\d+$/.test(rawId)) return null
+  return rawId
+}
+
+const getNeteaseScrobbleSourceId = (song, songId) => {
+  const sourceId =
+    song?.sourceInfo?.sourceId ||
+    song?.sourceInfo?.sourceid ||
+    song?.sourceInfo?.playlistId ||
+    song?.sourceInfo?.albumId ||
+    song?.albumId ||
+    songId
+
+  return String(sourceId || songId)
+}
+
+const getNeteaseScrobbleThreshold = (durationValue) => {
+  const normalizedDuration = normalizeSongDurationSeconds(durationValue)
+  if (!normalizedDuration) return NETEASE_SCROBBLE_MIN_SECONDS
+  return Math.min(
+    NETEASE_SCROBBLE_MIN_SECONDS,
+    Math.max(5, normalizedDuration * NETEASE_SCROBBLE_SHORT_AUDIO_RATIO)
+  )
+}
+
+const tryScrobbleNeteaseSong = async (currentTimeValue, durationValue) => {
+  if (!control.isPlaying.value || typeof window === 'undefined') return
+
+  const song = activeSong.value
+  const songId = getNeteaseScrobbleSongId(song)
+  if (!songId) return
+
+  const cookie = window.localStorage.getItem('netease_cookie')
+  if (!cookie) return
+
+  const threshold = getNeteaseScrobbleThreshold(durationValue)
+  if (currentTimeValue < threshold) return
+
+  const sourceId = getNeteaseScrobbleSourceId(song, songId)
+  const scrobbleKey = `${songId}:${sourceId}`
+  if (
+    neteaseScrobbleReportedKey.value === scrobbleKey ||
+    neteaseScrobblePendingKey.value === scrobbleKey
+  ) {
+    return
+  }
+
+  neteaseScrobblePendingKey.value = scrobbleKey
+  try {
+    const playTime = Math.max(
+      1,
+      Math.round(Math.min(currentTimeValue, normalizeSongDurationSeconds(durationValue) || currentTimeValue))
+    )
+
+    const result = await scrobbleSong(
+      {
+        id: songId,
+        sourceid: sourceId,
+        time: playTime
+      },
+      cookie
+    )
+
+    if (result?.code === 200 || result?.body?.code === 200 || result?.body?.data === 'success') {
+      neteaseScrobbleReportedKey.value = scrobbleKey
+    } else {
+      console.warn('[AudioPlayer] 网易云听歌打卡未成功:', result?.message || result)
+    }
+  } catch (scrobbleError) {
+    console.warn('[AudioPlayer] 网易云听歌打卡失败:', scrobbleError)
+  } finally {
+    if (neteaseScrobblePendingKey.value === scrobbleKey) {
+      neteaseScrobblePendingKey.value = null
+    }
+  }
+}
+
 // 音频事件处理器
 const handleTimeUpdate = () => {
   if (!audioPlayer.value || isSyncingFromGlobal.value) return
@@ -614,6 +703,7 @@ const handleTimeUpdate = () => {
   // 不传递song参数，避免覆盖已设置的元数据
   if (control.isPlaying.value) {
     sync.throttledProgressUpdate(currentTime, duration, control.isPlaying.value)
+    void tryScrobbleNeteaseSong(currentTime, duration)
   }
 }
 
@@ -901,6 +991,10 @@ const handleError = async (error) => {
 }
 
 const handleEnded = () => {
+  if (audioPlayer.value) {
+    void tryScrobbleNeteaseSong(audioPlayer.value.duration || control.currentTime.value, audioPlayer.value.duration)
+  }
+
   // 在执行 onEnded（可能会切换到下一首）之前，记录当前是否还有下一首
   const hasNextBeforeEnded = sync.globalAudioPlayer.hasNext.value
 

--- a/app/components/UI/AudioPlayer.vue
+++ b/app/components/UI/AudioPlayer.vue
@@ -335,6 +335,7 @@ const failedPlaybackSources = ref<string[]>([])
 const neteaseScrobbleReportedKey = ref<string | null>(null)
 const neteaseScrobblePendingKey = ref<string | null>(null)
 const neteaseScrobbleRetryCount = ref(0)
+const neteaseScrobbleWasPastThreshold = ref(false)
 
 // 获取音频播放器引用
 const audioPlayer = computed(() => audioElementRef.value?.audioPlayer)
@@ -473,6 +474,7 @@ watch(
       neteaseScrobbleReportedKey.value = null
       neteaseScrobblePendingKey.value = null
       neteaseScrobbleRetryCount.value = 0
+      neteaseScrobbleWasPastThreshold.value = false
       enhanced.resetRetryState()
     }
   }
@@ -636,6 +638,14 @@ const getNeteaseScrobbleThreshold = (durationValue) => {
   )
 }
 
+const resetNeteaseScrobbleStateForReplay = (scrobbleKey) => {
+  if (neteaseScrobbleReportedKey.value === scrobbleKey) {
+    neteaseScrobbleReportedKey.value = null
+  }
+  neteaseScrobbleRetryCount.value = 0
+  neteaseScrobbleWasPastThreshold.value = false
+}
+
 const tryScrobbleNeteaseSong = async (currentTimeValue, durationValue, isEnded = false) => {
   if ((!control.isPlaying.value && !isEnded) || typeof window === 'undefined') return
 
@@ -643,11 +653,17 @@ const tryScrobbleNeteaseSong = async (currentTimeValue, durationValue, isEnded =
   const songId = getNeteaseScrobbleSongId(song)
   if (!songId) return
 
-  const threshold = getNeteaseScrobbleThreshold(durationValue)
-  if (currentTimeValue < threshold) return
-
   const sourceId = getNeteaseScrobbleSourceId(song, songId)
   const scrobbleKey = `${songId}:${sourceId}`
+  const threshold = getNeteaseScrobbleThreshold(durationValue)
+  if (currentTimeValue < threshold) {
+    if (neteaseScrobbleWasPastThreshold.value) {
+      resetNeteaseScrobbleStateForReplay(scrobbleKey)
+    }
+    return
+  }
+
+  neteaseScrobbleWasPastThreshold.value = true
   if (
     neteaseScrobbleReportedKey.value === scrobbleKey ||
     neteaseScrobblePendingKey.value === scrobbleKey ||

--- a/app/utils/neteaseApi.ts
+++ b/app/utils/neteaseApi.ts
@@ -86,3 +86,7 @@ export async function getRecentSongs(limit = 100, cookie) {
 export async function getLoginStatus(cookie) {
   return fetchNetease('/login/status', {}, cookie)
 }
+
+export async function scrobbleSong(params, cookie) {
+  return fetchNetease('/scrobble', params, cookie)
+}


### PR DESCRIPTION
- 集成 scrobbleSong API 函数用于网易云听歌记录上报
- 实现网易云听歌打卡逻辑，支持播放进度超过阈值时自动打卡
- 添加打卡状态管理，防止重复提交相同的打卡请求
- 支持不同长度音频的动态打卡阈值计算
- 在播放结束时也触发打卡操作以确保记录完整
- 更新歌曲数据结构，增加 albumId 和 playlistId 字段
- 优化音频播放器组件的状态重置逻辑