### PR TITLE
ci(nix): 添加构建步骤验证 hash 并清理无用 CI 步骤

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,7 +11,6 @@ jobs:
   nix-check:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     steps:
       - name: Checkout repository
@@ -20,11 +19,8 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
 
-      - name: FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@main
-
-      - name: Flake Checker
-        uses: DeterminateSystems/flake-checker-action@main
-
       - name: Run nix flake check
         run: nix flake check
+
+      - name: Build voicehub (validate hashes)
+        run: nix build .#voicehub

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
               inherit (finalAttrs) pname version src;
               inherit pnpm;
               fetcherVersion = 4;
-              hash = "sha256-MGdGLwunE3U35l219/A+MzzY50I0JwM4YDRsoZsnoAA=";
+              hash = "sha256-15xSPRVUBB1D3ejtGtJAjKvY0BmJnMbxE71cVkeqius=";
             };
 
             nativeBuildInputs = [


### PR DESCRIPTION
Nix CI 之前只跑 nix flake check（仅求值不构建），依赖更新后 pnpmDeps
hash 不匹配无法被捕获，等到部署构建时才会暴露。

变更内容：
- 移除 FlakeHub Cache 步骤（OIDC 登录到不需要的 FlakeHub）
- 移除 Flake Checker 步骤（检查上游 flake.lock 时效性，fork 无意义）
- 移除 permissions.id-token: write（FlakeHub OIDC 不需要了）
- 新增 nix build .#voicehub 步骤，在求值后实际构建包，
  依赖 hash 不匹配时 CI 会直接报错，不再漏网
- 同步更新 flake.nix 中 pnpmDeps hash 至当前 lockfile 匹配值