### PR TITLE
ci(nix): 集成 Cachix binary cache 加速构建

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -23,7 +23,7 @@ jobs:
         uses: cachix/cachix-action@v14
         with:
           name: voicehub
-          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+          signingKey: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Run nix flake check
         run: nix flake check

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
 
+      - name: Setup Cachix binary cache
+        uses: cachix/cachix-action@v14
+        with:
+          name: voicehub
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+
       - name: Run nix flake check
         run: nix flake check
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "VoiceHub - 校园广播站点歌管理系统";
 
+  nixConfig = {
+    extra-substituters = [ "https://voicehub.cachix.org" ];
+    extra-trusted-public-keys = [ "voicehub.cachix.org-1:<请替换为实际 public key>" ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   nixConfig = {
     extra-substituters = [ "https://voicehub.cachix.org" ];
-    extra-trusted-public-keys = [ "voicehub.cachix.org-1:<请替换为实际 public key>" ];
+    extra-trusted-public-keys = [ "voicehub.cachix.org-1:CKw4/RvZy5c0WVpyo5ZyLbJgdpHZ/+epofIwGOeIOhU=" ];
   };
 
   inputs = {


### PR DESCRIPTION
在 Nix CI 中引入 cachix-action，每次构建后自动将 pnpmDeps 和 voicehub 产物推送到 Cachix binary cache。用户通过 flake 的 nixConfig 提示自动拉取预构建产物，避免重复构建。

需维护者操作：
1. 在 https://app.cachix.org 注册并创建 cache（建议名称 voicehub）
2. 将 signing key 设为 GitHub Secret：CACHIX_SIGNING_KEY
3. 使用 public key 更新 PR 中 flake.nix 中的占位符

Closed #444