### PR TITLE
feat(nix): 添加 openFirewall 选项以在 NixOS 模块中开放防火墙端口

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,11 @@ NUXT_PUBLIC_HOST=https://voicehub.example.com
 推荐使用 [sops-nix](https://github.com/Mic92/sops-nix) 管理 secrets，避免明文存储在 Nix store 中。
 
 模块会自动设置 `DynamicUser`、`ProtectSystem=strict`、`NoNewPrivileges` 等安全加固。
+防火墙默认不开放端口，在配置中启用以允许外部访问：
+
+```nix
+services.voicehub.openFirewall = true;
+```
 
 应用配置并部署：
 

--- a/flake.nix
+++ b/flake.nix
@@ -263,6 +263,12 @@
                 当使用独立的迁移流程时可设为 false。
               '';
             };
+
+            openFirewall = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = "在防火墙中开放 VoiceHub 端口";
+            };
           };
 
           config = lib.mkIf cfg.enable {
@@ -271,6 +277,8 @@
               ensureDatabases = [ cfg.database.name ];
               ensureUsers = [{ name = cfg.database.user; ensureDBOwnership = true; }];
             };
+
+            networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ cfg.port ];
 
             systemd.services.voicehub = {
               description = "VoiceHub - 校园广播站点歌服务";


### PR DESCRIPTION
NixOS 模块新增 `services.voicehub.openFirewall` 选项（默认 `false`），启用后自动将 `services.voicehub.port` 加入 `networking.firewall.allowedTCPPorts`。
遵循 nixpkgs 惯例，与 `services.jellyfin.openFirewall` 等模块一致。README 中同步补充了防火墙说明与启用示例。