### PR TITLE
feat: 增加点歌券突破投稿限额功能

### DIFF
--- a/app/components/Admin/SiteConfigManager.vue
+++ b/app/components/Admin/SiteConfigManager.vue
@@ -206,6 +206,32 @@
           </div>
 
           <div
+            :class="[
+              'flex items-center justify-between p-3 bg-zinc-950/50 border border-zinc-800 rounded-xl transition-opacity',
+              !formData.enableSubmissionLimit ||
+              (!formData.enableCardCodeRequests && !formData.requireCardCodeForRequests)
+                ? 'opacity-50'
+                : ''
+            ]"
+          >
+            <div class="pr-4">
+              <p class="text-xs font-bold text-zinc-200">允许点歌券突破投稿限额</p>
+              <p class="text-[10px] text-zinc-500 mt-0.5">
+                开启后，有效点歌券投稿不占普通额度，并可在日、周或月额度用完后继续投稿
+              </p>
+            </div>
+            <input
+              v-model="formData.enableCardCodeLimitBypass"
+              type="checkbox"
+              :disabled="
+                !formData.enableSubmissionLimit ||
+                (!formData.enableCardCodeRequests && !formData.requireCardCodeForRequests)
+              "
+              class="w-5 h-5 rounded border-zinc-800 bg-zinc-900 accent-blue-600 cursor-pointer disabled:cursor-not-allowed"
+            >
+          </div>
+
+          <div
             class="flex items-center justify-between p-3 bg-zinc-950/50 border border-zinc-800 rounded-xl"
           >
             <div>
@@ -534,6 +560,7 @@ const formData = ref({
   // 点歌券点歌设置
   enableCardCodeRequests: false,
   requireCardCodeForRequests: false,
+  enableCardCodeLimitBypass: false,
   dailySubmissionLimit: 5,
   weeklySubmissionLimit: null,
   monthlySubmissionLimit: null,
@@ -639,6 +666,7 @@ const loadConfig = async () => {
       // 点歌券点歌设置
       enableCardCodeRequests: !!data.enableCardCodeRequests,
       requireCardCodeForRequests: !!data.requireCardCodeForRequests,
+      enableCardCodeLimitBypass: !!data.enableCardCodeLimitBypass,
       dailySubmissionLimit: data.dailySubmissionLimit ?? 5,
       weeklySubmissionLimit: data.weeklySubmissionLimit ?? null,
       monthlySubmissionLimit: data.monthlySubmissionLimit ?? null,

--- a/app/components/Songs/RequestForm.vue
+++ b/app/components/Songs/RequestForm.vue
@@ -127,7 +127,13 @@
         <div class="search-results-container">
           <!-- 投稿状态显示 - 横向布局，只在设置了限额时显示 -->
           <div
-            v-if="user && submissionStatus && submissionStatus.limitEnabled"
+            v-if="
+              user &&
+              submissionStatus &&
+              (submissionStatus.limitEnabled ||
+                submissionStatus.timeLimitationEnabled ||
+                submissionStatus.submissionClosed)
+            "
             class="submission-status-horizontal"
           >
             <!-- 超级管理员提示 -->
@@ -204,6 +210,14 @@
                     Math.max(0, submissionStatus.monthlyLimit - submissionStatus.monthlyUsed)
                   }}</span
                 >
+              </div>
+
+              <div
+                v-if="cardCodeLimitBypassActive"
+                class="status-item-horizontal"
+              >
+                <span class="status-label">点歌券：</span>
+                <span class="status-value">不占普通额度</span>
               </div>
             </div>
           </div>
@@ -1377,8 +1391,10 @@ const {
   enableReplayRequests,
   enableCollaborativeSubmission,
   enableSubmissionRemarks,
+  enableSubmissionLimit,
   enableCardCodeRequests,
-  requireCardCodeForRequests
+  requireCardCodeForRequests,
+  enableCardCodeLimitBypass
 } = useSiteConfig()
 
 // 用户认证
@@ -1441,19 +1457,30 @@ const playTimes = ref([])
 const playTimeSelectionEnabled = ref(false)
 const loadingPlayTimes = ref(false)
 
+const cardCodeEnabled = computed(() => enableCardCodeRequests.value || requireCardCodeForRequests.value)
+const cardCodeLimitBypassActive = computed(
+  () => enableSubmissionLimit.value && cardCodeEnabled.value && enableCardCodeLimitBypass.value
+)
+
 const cardCodeFieldMeta = computed(() => ({
   required: requireCardCodeForRequests.value,
   helper: requireCardCodeForRequests.value
-    ? '开启强制点歌券后，提交点歌时必须填写有效点歌券。'
-    : '填写点歌券可用于抵扣或提交点歌。',
+    ? cardCodeLimitBypassActive.value
+      ? '提交点歌时必须填写有效点歌券；点歌券投稿不占普通额度。'
+      : '开启强制点歌券后，提交点歌时必须填写有效点歌券。'
+    : cardCodeLimitBypassActive.value
+      ? '使用有效点歌券可突破个人投稿限额，且不占普通额度。'
+      : '填写点歌券可用于抵扣或提交点歌。',
   placeholder: '请输入点歌券'
 }))
 
-const cardCodeEnabled = computed(() => enableCardCodeRequests.value || requireCardCodeForRequests.value)
 const trimmedCardCode = computed(() => cardCode.value.trim())
 const cardCodeStatusText = computed(() => {
   if (cardCodeValidation.value.checking) return '正在验证点歌券...'
   if (trimmedCardCode.value) {
+    if (cardCodeValidation.value.valid && cardCodeLimitBypassActive.value) {
+      return '点歌券可用，不占普通额度'
+    }
     return cardCodeValidation.value.message || '已填写点歌券，提交前会验证'
   }
   return cardCodeFieldMeta.value.required ? '提交前需要添加有效点歌券' : '可选添加点歌券'
@@ -3772,7 +3799,7 @@ const checkSubmissionLimit = () => {
     return { canSubmit: true, message: '' }
   }
 
-  if (!submissionStatus.value || !submissionStatus.value.limitEnabled) {
+  if (!submissionStatus.value) {
     return { canSubmit: true, message: '' }
   }
 
@@ -3797,6 +3824,18 @@ const checkSubmissionLimit = () => {
         message: `当前时段投稿名额已满 (${accepted}/${expected})`
       }
     }
+  }
+
+  if (!submissionStatus.value.limitEnabled) {
+    return { canSubmit: true, message: '' }
+  }
+
+  if (
+    cardCodeLimitBypassActive.value &&
+    trimmedCardCode.value &&
+    cardCodeValidation.value.valid === true
+  ) {
+    return { canSubmit: true, message: '' }
   }
 
   const { dailyLimit, weeklyLimit, monthlyLimit, dailyUsed, weeklyUsed, monthlyUsed } =

--- a/app/composables/useSiteConfig.js
+++ b/app/composables/useSiteConfig.js
@@ -22,8 +22,10 @@ const siteConfig = ref({
   captchaEnabled: false,
   captchaProvider: 'graphic',
   turnstileSiteKey: '',
+  enableSubmissionLimit: false,
   enableCardCodeRequests: false,
   requireCardCodeForRequests: false,
+  enableCardCodeLimitBypass: false,
   githubOAuthEnabled: false,
   casdoorOAuthEnabled: false,
   googleOAuthEnabled: false,
@@ -70,8 +72,10 @@ export const useSiteConfig = () => {
         captchaEnabled: false,
         captchaProvider: 'graphic',
         turnstileSiteKey: '',
+        enableSubmissionLimit: false,
         enableCardCodeRequests: false,
         requireCardCodeForRequests: false,
+        enableCardCodeLimitBypass: false,
         githubOAuthEnabled: false,
         casdoorOAuthEnabled: false,
         googleOAuthEnabled: false,
@@ -103,8 +107,12 @@ export const useSiteConfig = () => {
     () => siteConfig.value.enableCollaborativeSubmission !== false
   )
   const enableSubmissionRemarks = computed(() => siteConfig.value.enableSubmissionRemarks === true)
+  const enableSubmissionLimit = computed(() => siteConfig.value.enableSubmissionLimit === true)
   const enableCardCodeRequests = computed(() => siteConfig.value.enableCardCodeRequests === true)
   const requireCardCodeForRequests = computed(() => siteConfig.value.requireCardCodeForRequests === true)
+  const enableCardCodeLimitBypass = computed(
+    () => siteConfig.value.enableCardCodeLimitBypass === true
+  )
   const allowOAuthRegistration = computed(() => siteConfig.value.allowOAuthRegistration === true)
   const captchaEnabled = computed(() => siteConfig.value.captchaEnabled === true)
   const captchaProvider = computed(() => siteConfig.value.captchaProvider || 'graphic')
@@ -166,8 +174,10 @@ export const useSiteConfig = () => {
     enableReplayRequests,
     enableCollaborativeSubmission,
     enableSubmissionRemarks,
+    enableSubmissionLimit,
     enableCardCodeRequests,
     requireCardCodeForRequests,
+    enableCardCodeLimitBypass,
     allowOAuthRegistration,
     captchaEnabled,
     captchaProvider,

--- a/app/drizzle/migrations/20260710133348_add_card_code_limit_bypass.sql
+++ b/app/drizzle/migrations/20260710133348_add_card_code_limit_bypass.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "SystemSettings" ADD COLUMN "enableCardCodeLimitBypass" boolean DEFAULT false NOT NULL;

--- a/app/drizzle/migrations/meta/20260710133348_snapshot.json
+++ b/app/drizzle/migrations/meta/20260710133348_snapshot.json
@@ -1,0 +1,2162 @@
+{
+  "id": "02d1226c-1a29-4830-a564-721b79898593",
+  "prevId": "613c2614-a286-4598-b4c5-a46792bd6e46",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_key_permissions": {
+      "name": "api_key_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_logs": {
+      "name": "api_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CardCodeRedeemLog": {
+      "name": "CardCodeRedeemLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cardCodeId": {
+          "name": "cardCodeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codeSnapshot": {
+          "name": "codeSnapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemedBy": {
+          "name": "redeemedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemedAt": {
+          "name": "redeemedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UNKNOWN'"
+        },
+        "songId": {
+          "name": "songId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "card_code_redeem_log_card_code_id_idx": {
+          "name": "card_code_redeem_log_card_code_id_idx",
+          "columns": [
+            {
+              "expression": "cardCodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "CardCodeRedeemLog_cardCodeId_CardCode_id_fk": {
+          "name": "CardCodeRedeemLog_cardCodeId_CardCode_id_fk",
+          "tableFrom": "CardCodeRedeemLog",
+          "tableTo": "CardCode",
+          "columnsFrom": [
+            "cardCodeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "CardCodeRedeemLog_redeemedBy_User_id_fk": {
+          "name": "CardCodeRedeemLog_redeemedBy_User_id_fk",
+          "tableFrom": "CardCodeRedeemLog",
+          "tableTo": "User",
+          "columnsFrom": [
+            "redeemedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "CardCodeRedeemLog_songId_Song_id_fk": {
+          "name": "CardCodeRedeemLog_songId_Song_id_fk",
+          "tableFrom": "CardCodeRedeemLog",
+          "tableTo": "Song",
+          "columnsFrom": [
+            "songId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CardCode": {
+      "name": "CardCode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "card_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "lockedBy": {
+          "name": "lockedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lockedAt": {
+          "name": "lockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemedBy": {
+          "name": "redeemedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemedAt": {
+          "name": "redeemedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "CardCode_lockedBy_User_id_fk": {
+          "name": "CardCode_lockedBy_User_id_fk",
+          "tableFrom": "CardCode",
+          "tableTo": "User",
+          "columnsFrom": [
+            "lockedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "CardCode_redeemedBy_User_id_fk": {
+          "name": "CardCode_redeemedBy_User_id_fk",
+          "tableFrom": "CardCode",
+          "tableTo": "User",
+          "columnsFrom": [
+            "redeemedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "CardCode_code_unique": {
+          "name": "CardCode_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaboration_logs": {
+      "name": "collaboration_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "collaborator_id": {
+          "name": "collaborator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EmailTemplate": {
+      "name": "EmailTemplate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(300)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedByUserId": {
+          "name": "updatedByUserId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NotificationSettings": {
+      "name": "NotificationSettings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "songRequestEnabled": {
+          "name": "songRequestEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "songVotedEnabled": {
+          "name": "songVotedEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "songPlayedEnabled": {
+          "name": "songPlayedEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "refreshInterval": {
+          "name": "refreshInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "songVotedThreshold": {
+          "name": "songVotedThreshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Notification": {
+      "name": "Notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "songId": {
+          "name": "songId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PlayTime": {
+      "name": "PlayTime",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RequestTime": {
+      "name": "RequestTime",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp(6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected": {
+          "name": "expected",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "past": {
+          "name": "past",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Schedule": {
+      "name": "Schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "songId": {
+          "name": "songId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playDate": {
+          "name": "playDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "played": {
+          "name": "played",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "playTimeId": {
+          "name": "playTimeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDraft": {
+          "name": "isDraft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Semester": {
+      "name": "Semester",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SongBlacklist": {
+      "name": "SongBlacklist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "BlacklistType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.song_collaborators": {
+      "name": "song_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "collaborator_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.song_replay_requests": {
+      "name": "song_replay_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "replay_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "song_replay_requests_song_id_user_id_unique": {
+          "name": "song_replay_requests_song_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "song_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Song": {
+      "name": "Song",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requesterId": {
+          "name": "requesterId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "played": {
+          "name": "played",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "playedAt": {
+          "name": "playedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "semester": {
+          "name": "semester",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferredPlayTimeId": {
+          "name": "preferredPlayTimeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playUrl": {
+          "name": "playUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicPlatform": {
+          "name": "musicPlatform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "musicId": {
+          "name": "musicId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submissionNote": {
+          "name": "submissionNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submissionNotePublic": {
+          "name": "submissionNotePublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hitRequestId": {
+          "name": "hitRequestId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cardCodeId": {
+          "name": "cardCodeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "song_card_code_id_idx": {
+          "name": "song_card_code_id_idx",
+          "columns": [
+            {
+              "expression": "cardCodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Song_cardCodeId_CardCode_id_fk": {
+          "name": "Song_cardCodeId_CardCode_id_fk",
+          "tableFrom": "Song",
+          "tableTo": "CardCode",
+          "columnsFrom": [
+            "cardCodeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SystemSettings": {
+      "name": "SystemSettings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telemetryEnabled": {
+          "name": "telemetryEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enablePlayTimeSelection": {
+          "name": "enablePlayTimeSelection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "siteTitle": {
+          "name": "siteTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siteLogoUrl": {
+          "name": "siteLogoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schoolLogoHomeUrl": {
+          "name": "schoolLogoHomeUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schoolLogoPrintUrl": {
+          "name": "schoolLogoPrintUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siteDescription": {
+          "name": "siteDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submissionGuidelines": {
+          "name": "submissionGuidelines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icpNumber": {
+          "name": "icpNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gonganNumber": {
+          "name": "gonganNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "showBeianIcon": {
+          "name": "showBeianIcon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enableSubmissionLimit": {
+          "name": "enableSubmissionLimit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dailySubmissionLimit": {
+          "name": "dailySubmissionLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weeklySubmissionLimit": {
+          "name": "weeklySubmissionLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlySubmissionLimit": {
+          "name": "monthlySubmissionLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "showBlacklistKeywords": {
+          "name": "showBlacklistKeywords",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hideStudentInfo": {
+          "name": "hideStudentInfo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "smtpEnabled": {
+          "name": "smtpEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "smtpHost": {
+          "name": "smtpHost",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtpPort": {
+          "name": "smtpPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtpSecure": {
+          "name": "smtpSecure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtpUsername": {
+          "name": "smtpUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtpPassword": {
+          "name": "smtpPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtpFromEmail": {
+          "name": "smtpFromEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smtpFromName": {
+          "name": "smtpFromName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'校园广播站'"
+        },
+        "enableRequestTimeLimitation": {
+          "name": "enableRequestTimeLimitation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forceBlockAllRequests": {
+          "name": "forceBlockAllRequests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enableReplayRequests": {
+          "name": "enableReplayRequests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enableCollaborativeSubmission": {
+          "name": "enableCollaborativeSubmission",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enableSubmissionRemarks": {
+          "name": "enableSubmissionRemarks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enableCardCodeRequests": {
+          "name": "enableCardCodeRequests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requireCardCodeForRequests": {
+          "name": "requireCardCodeForRequests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enableCardCodeLimitBypass": {
+          "name": "enableCardCodeLimitBypass",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captchaProvider": {
+          "name": "captchaProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'graphic'"
+        },
+        "turnstileSiteKey": {
+          "name": "turnstileSiteKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnstileSecretKey": {
+          "name": "turnstileSecretKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowOAuthRegistration": {
+          "name": "allowOAuthRegistration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "oauthRedirectUri": {
+          "name": "oauthRedirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthStateSecret": {
+          "name": "oauthStateSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthProviders": {
+          "name": "oauthProviders",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "githubOAuthEnabled": {
+          "name": "githubOAuthEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "githubClientId": {
+          "name": "githubClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubClientSecret": {
+          "name": "githubClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "casdoorOAuthEnabled": {
+          "name": "casdoorOAuthEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "casdoorServerUrl": {
+          "name": "casdoorServerUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "casdoorClientId": {
+          "name": "casdoorClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "casdoorClientSecret": {
+          "name": "casdoorClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "casdoorOrganizationName": {
+          "name": "casdoorOrganizationName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleOAuthEnabled": {
+          "name": "googleOAuthEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "googleClientId": {
+          "name": "googleClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleClientSecret": {
+          "name": "googleClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthEnabled": {
+          "name": "customOAuthEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customOAuthDisplayName": {
+          "name": "customOAuthDisplayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthAuthorizeUrl": {
+          "name": "customOAuthAuthorizeUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthTokenUrl": {
+          "name": "customOAuthTokenUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthUserInfoUrl": {
+          "name": "customOAuthUserInfoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthScope": {
+          "name": "customOAuthScope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthClientId": {
+          "name": "customOAuthClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthClientSecret": {
+          "name": "customOAuthClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthUserIdField": {
+          "name": "customOAuthUserIdField",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthUsernameField": {
+          "name": "customOAuthUsernameField",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthNameField": {
+          "name": "customOAuthNameField",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthEmailField": {
+          "name": "customOAuthEmailField",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customOAuthAvatarField": {
+          "name": "customOAuthAvatarField",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captchaEnabled": {
+          "name": "captchaEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "captchaMaxFailures": {
+          "name": "captchaMaxFailures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserIdentity": {
+      "name": "UserIdentity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerUserId": {
+          "name": "providerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerUsername": {
+          "name": "providerUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UserIdentity_userId_User_id_fk": {
+          "name": "UserIdentity_userId_User_id_fk",
+          "tableFrom": "UserIdentity",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UserIdentity_provider_providerUserId_unique": {
+          "name": "UserIdentity_provider_providerUserId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "providerUserId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_status_logs": {
+      "name": "user_status_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_status": {
+          "name": "old_status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "lastLogin": {
+          "name": "lastLogin",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastLoginIp": {
+          "name": "lastLoginIp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passwordChangedAt": {
+          "name": "passwordChangedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forcePasswordChange": {
+          "name": "forcePasswordChange",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "meowNickname": {
+          "name": "meowNickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meowBoundAt": {
+          "name": "meowBoundAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "statusChangedAt": {
+          "name": "statusChangedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "statusChangedBy": {
+          "name": "statusChangedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "songId": {
+          "name": "songId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.BlacklistType": {
+      "name": "BlacklistType",
+      "schema": "public",
+      "values": [
+        "SONG",
+        "KEYWORD"
+      ]
+    },
+    "public.card_code_status": {
+      "name": "card_code_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "LOCKED",
+        "REDEEMED",
+        "INVALID"
+      ]
+    },
+    "public.collaborator_status": {
+      "name": "collaborator_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "REJECTED"
+      ]
+    },
+    "public.replay_request_status": {
+      "name": "replay_request_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "FULFILLED",
+        "REJECTED"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "withdrawn",
+        "graduate"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/drizzle/migrations/meta/_journal.json
+++ b/app/drizzle/migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1782527721417,
       "tag": "20260627023521_add_card_code_foreign_key_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1783690428462,
+      "tag": "20260710133348_add_card_code_limit_bypass",
+      "breakpoints": true
     }
   ]
 }

--- a/app/drizzle/schema.ts
+++ b/app/drizzle/schema.ts
@@ -171,6 +171,7 @@ export const systemSettings = pgTable('SystemSettings', {
   // 卡密点歌相关开关（用于允许用户使用卡密或强制使用卡密投稿）
   enableCardCodeRequests: boolean('enableCardCodeRequests').default(false).notNull(),
   requireCardCodeForRequests: boolean('requireCardCodeForRequests').default(false).notNull(),
+  enableCardCodeLimitBypass: boolean('enableCardCodeLimitBypass').default(false).notNull(),
   
   // 验证码配置
   captchaProvider: text('captchaProvider').default('graphic').notNull(),

--- a/scripts/db-sync.js
+++ b/scripts/db-sync.js
@@ -89,7 +89,7 @@ function loadMigrationJournalEntries() {
   return [...journal.entries].sort((a, b) => a.when - b.when)
 }
 
-async function seedLegacyMigrationRecords(sql) {
+async function seedMissingMigrationRecords(sql) {
   const entries = loadMigrationJournalEntries()
 
   await sql`CREATE TABLE IF NOT EXISTS public.__drizzle_migrations__ (
@@ -278,6 +278,28 @@ async function checkSchemaConsistency(sql) {
   return true
 }
 
+async function repairSchemaWithPush(sql) {
+  const pushCommand = 'pnpm exec drizzle-kit push --force --config=drizzle.config.ts'
+  if (
+    !safeExec(pushCommand, {
+      env: { ...NON_INTERACTIVE_ENV, DRIZZLE_KIT_NON_INTERACTIVE: 'true' }
+    })
+  ) {
+    err('数据库schema修复失败')
+    return false
+  }
+
+  if (!(await checkSchemaConsistency(sql))) {
+    err('push 后数据库schema仍不完整')
+    return false
+  }
+
+  // push 只同步结构，不会写入迁移表；补齐记录可避免后续 migrate 重放已存在的结构。
+  await seedMissingMigrationRecords(sql)
+  ok('强制同步完成，迁移记录已补齐')
+  return true
+}
+
 async function main() {
   log('🔄 数据库同步', 'cyan')
 
@@ -298,64 +320,48 @@ async function main() {
         err('数据库迁移失败')
         process.exit(1)
       }
+      if (!(await checkSchemaConsistency(sql))) {
+        err('空库迁移后数据库schema仍不完整')
+        process.exit(1)
+      }
       ok('空库迁移完成')
     } else {
-      log('🔁 检测到非空库，检查schema一致性...', 'cyan')
-
       const migrationRecordsExist = await hasMigrationRecords(sql)
-      let schemaConsistent = await checkSchemaConsistency(sql)
-
-      if (!schemaConsistent) {
-        warn('数据库schema不完整，尝试使用 push --force 进行修复...', 'cyan')
-        const pushCommand = 'pnpm exec drizzle-kit push --force --config=drizzle.config.ts'
-        if (
-          !safeExec(pushCommand, {
-            env: { ...NON_INTERACTIVE_ENV, DRIZZLE_KIT_NON_INTERACTIVE: 'true' }
-          })
-        ) {
-          err('数据库schema修复失败')
-          process.exit(1)
-        }
-        schemaConsistent = await checkSchemaConsistency(sql)
-        if (!schemaConsistent) {
-          err('push 后数据库schema仍不完整')
-          process.exit(1)
-        }
-        ok('schema修复成功')
-
-        if (!migrationRecordsExist) {
-          warn('检测到 legacy 数据库迁移记录为空，写入迁移基线记录以便后续版本继续 migrate。')
-          await seedLegacyMigrationRecords(sql)
-          ok('legacy 迁移基线记录写入完成')
-        }
-      } else if (!migrationRecordsExist) {
-        warn('检测到 legacy 数据库：schema 已存在，但迁移记录为空。跳过 migrate 以避免重放历史迁移。')
-        await seedLegacyMigrationRecords(sql)
-        ok('legacy schema 检查通过，迁移基线记录写入完成')
-      } else {
-        log('🔁 数据库schema一致，尝试执行 migrate 同步...', 'cyan')
-
+      if (migrationRecordsExist) {
+        // 正常数据库必须先应用待执行迁移，再检查最终结构；否则新增字段会被误判为schema损坏。
+        log('🔁 检测到迁移记录，先执行 migrate 同步...', 'cyan')
         const migrateSuccess = safeExec('pnpm run db:migrate', {
           env: { ...NON_INTERACTIVE_ENV, DRIZZLE_KIT_NON_INTERACTIVE: 'true' }
         })
 
-        if (migrateSuccess) {
+        const schemaConsistent = migrateSuccess && (await checkSchemaConsistency(sql))
+        if (migrateSuccess && schemaConsistent) {
           ok('migrate 同步成功')
         } else {
-          warn('migrate 同步失败，可能是由于数据库结构与迁移记录不一致。')
+          if (migrateSuccess) {
+            warn('migrate 已执行，但数据库schema仍不完整。')
+          } else {
+            warn('migrate 同步失败，可能是由于数据库结构与迁移记录不一致。')
+          }
           log('🔄 尝试使用 push --force 进行强制同步...', 'cyan')
-
-          const pushCommand = 'pnpm exec drizzle-kit push --force --config=drizzle.config.ts'
-          if (
-            !safeExec(pushCommand, {
-              env: { ...NON_INTERACTIVE_ENV, DRIZZLE_KIT_NON_INTERACTIVE: 'true' }
-            })
-          ) {
-            err('数据库同步完全失败。请检查数据库连接或手动运行 pnpm exec drizzle-kit push 以解决歧义。')
+          if (!(await repairSchemaWithPush(sql))) {
+            err('数据库同步完全失败。请检查数据库连接或迁移文件。')
             process.exit(1)
           }
-          ok('强制同步 (push) 成功')
         }
+      } else {
+        warn('检测到 legacy 数据库迁移记录为空，检查schema并写入迁移基线。')
+        const schemaConsistent = await checkSchemaConsistency(sql)
+
+        if (!schemaConsistent) {
+          log('🔄 legacy schema不完整，尝试使用 push --force 进行同步...', 'cyan')
+          if (!(await repairSchemaWithPush(sql))) {
+            process.exit(1)
+          }
+        } else {
+          await seedMissingMigrationRecords(sql)
+        }
+        ok('legacy schema同步完成，迁移基线记录已写入')
       }
     }
   } finally {

--- a/scripts/db-sync.js
+++ b/scripts/db-sync.js
@@ -204,6 +204,7 @@ async function checkSchemaConsistency(sql) {
       'enableSubmissionRemarks',
       'enableCardCodeRequests',
       'requireCardCodeForRequests',
+      'enableCardCodeLimitBypass',
       'captchaProvider',
       'turnstileSiteKey',
       'turnstileSecretKey',

--- a/server/api/admin/backup/restore-chunk.post.ts
+++ b/server/api/admin/backup/restore-chunk.post.ts
@@ -697,6 +697,7 @@ export default defineEventHandler(async (event) => {
               'enableSubmissionRemarks',
               'enableCardCodeRequests',
               'requireCardCodeForRequests',
+              'enableCardCodeLimitBypass',
               'enableRequestTimeLimitation',
               'requestTimeLimitation',
               'forceBlockAllRequests',

--- a/server/api/admin/backup/restore.post.ts
+++ b/server/api/admin/backup/restore.post.ts
@@ -1129,6 +1129,7 @@ export default defineEventHandler(async (event) => {
                           'enableSubmissionRemarks',
                           'enableCardCodeRequests',
                           'requireCardCodeForRequests',
+                          'enableCardCodeLimitBypass',
                           'hideStudentInfo',
                           'smtpEnabled',
                           'smtpHost',

--- a/server/api/admin/system-settings/index.post.ts
+++ b/server/api/admin/system-settings/index.post.ts
@@ -135,6 +135,16 @@ export default defineEventHandler(async (event) => {
       updateData.requireCardCodeForRequests = body.requireCardCodeForRequests
     }
 
+    if (body.enableCardCodeLimitBypass !== undefined) {
+      if (typeof body.enableCardCodeLimitBypass !== 'boolean') {
+        throw createError({
+          statusCode: 400,
+          message: 'enableCardCodeLimitBypass 必须是布尔值'
+        })
+      }
+      updateData.enableCardCodeLimitBypass = body.enableCardCodeLimitBypass
+    }
+
     if (body.dailySubmissionLimit !== undefined) {
       if (
         body.dailySubmissionLimit !== null &&
@@ -666,4 +676,3 @@ export default defineEventHandler(async (event) => {
     })
   }
 })
-

--- a/server/api/songs/submission-status.get.ts
+++ b/server/api/songs/submission-status.get.ts
@@ -1,15 +1,8 @@
 import { db } from '~/drizzle/db'
-import { requestTimes, songs, systemSettings } from '~/drizzle/schema'
-import { and, count, eq, gt, gte, lt, lte } from 'drizzle-orm'
-import {
-  getBeijingEndOfDay,
-  getBeijingEndOfWeek,
-  getBeijingEndOfMonth,
-  getBeijingStartOfDay,
-  getBeijingStartOfWeek,
-  getBeijingStartOfMonth,
-  getBeijingTimeISOString
-} from '~/utils/timeUtils'
+import { requestTimes, systemSettings } from '~/drizzle/schema'
+import { and, eq, gt, lte } from 'drizzle-orm'
+import { getBeijingTimeISOString } from '~/utils/timeUtils'
+import { getSubmissionCount, isCardCodeLimitBypassActive } from '~~/server/utils/submissionLimit'
 
 export default defineEventHandler(async (event) => {
   // 检查用户认证
@@ -42,7 +35,7 @@ export default defineEventHandler(async (event) => {
       dailyRemaining: null,
       weeklyRemaining: null,
       monthlyRemaining: null,
-      submissionClosed: false,
+      submissionClosed: !!(systemSettingsData?.forceBlockAllRequests && !isAdmin),
       timeLimitationEnabled: systemSettingsData?.enableRequestTimeLimitation || false,
       currentTimePeriod: null
     }
@@ -111,54 +104,14 @@ export default defineEventHandler(async (event) => {
     let weeklyUsed = 0
     let monthlyUsed = 0
 
+    const excludeCardCodeRequests = isCardCodeLimitBypassActive(systemSettingsData)
+
     if (limitType === 'daily' && effectiveLimit && effectiveLimit > 0) {
-      const startOfDay = getBeijingStartOfDay()
-      const endOfDay = getBeijingEndOfDay()
-
-      const dailyUsedResult = await db
-        .select({ count: count() })
-        .from(songs)
-        .where(
-          and(
-            eq(songs.requesterId, user.id),
-            gte(songs.createdAt, startOfDay),
-            lte(songs.createdAt, endOfDay)
-          )
-        )
-
-      dailyUsed = dailyUsedResult[0]?.count || 0
+      dailyUsed = await getSubmissionCount(db, user.id, 'daily', { excludeCardCodeRequests })
     } else if (limitType === 'weekly' && effectiveLimit && effectiveLimit > 0) {
-      const startOfWeek = getBeijingStartOfWeek()
-      const endOfWeek = getBeijingEndOfWeek()
-
-      const weeklyUsedResult = await db
-        .select({ count: count() })
-        .from(songs)
-        .where(
-          and(
-            eq(songs.requesterId, user.id),
-            gte(songs.createdAt, startOfWeek),
-            lte(songs.createdAt, endOfWeek)
-          )
-        )
-
-      weeklyUsed = weeklyUsedResult[0]?.count || 0
+      weeklyUsed = await getSubmissionCount(db, user.id, 'weekly', { excludeCardCodeRequests })
     } else if (limitType === 'monthly' && effectiveLimit && effectiveLimit > 0) {
-      const startOfMonth = getBeijingStartOfMonth()
-      const endOfMonth = getBeijingEndOfMonth()
-
-      const monthlyUsedResult = await db
-        .select({ count: count() })
-        .from(songs)
-        .where(
-          and(
-            eq(songs.requesterId, user.id),
-            gte(songs.createdAt, startOfMonth),
-            lte(songs.createdAt, endOfMonth)
-          )
-        )
-
-      monthlyUsed = monthlyUsedResult[0]?.count || 0
+      monthlyUsed = await getSubmissionCount(db, user.id, 'monthly', { excludeCardCodeRequests })
     }
 
     status.dailyLimit = limitType === 'daily' ? effectiveLimit : null

--- a/server/api/songs/withdraw.post.ts
+++ b/server/api/songs/withdraw.post.ts
@@ -10,7 +10,11 @@ import {
   requestTimes
 } from '~/drizzle/schema'
 import { and, eq, sql } from 'drizzle-orm'
-import { getTimeRange, type LimitType } from '~~/server/utils/submissionLimit'
+import {
+  getTimeRange,
+  isCardCodeLimitBypassActive,
+  type LimitType
+} from '~~/server/utils/submissionLimit'
 import { releaseCardCodeAfterSongWithdrawal } from '~~/server/services/cardCodeLifecycleService'
 
 export default defineEventHandler(async (event) => {
@@ -119,26 +123,32 @@ export default defineEventHandler(async (event) => {
   // 获取系统设置以检查限制类型
   const settingsResult = await db.select().from(systemSettings).limit(1)
   const settings = settingsResult[0]
-  const dailyLimit = settings?.dailySubmissionLimit || 0
-  const weeklyLimit = settings?.weeklySubmissionLimit || 0
-  const monthlyLimit = settings?.monthlySubmissionLimit || 0
 
   // 检查撤销的歌曲是否在当前限制期间内（用于返还配额）
   let canReturnQuota = false
 
-  const limitConfigs: { type: LimitType; value: number }[] = [
-    { type: 'daily', value: dailyLimit },
-    { type: 'weekly', value: weeklyLimit },
-    { type: 'monthly', value: monthlyLimit }
-  ]
+  const cardCodeDidNotUseOrdinaryQuota =
+    isCardCodeLimitBypassActive(settings) && !!song.cardCodeId
 
-  for (const { type, value } of limitConfigs) {
-    if (value > 0) {
-      const { start, end } = getTimeRange(type)
-      if (song.createdAt >= start && song.createdAt <= end) {
-        canReturnQuota = true
-        break
-      }
+  if (settings?.enableSubmissionLimit && !cardCodeDidNotUseOrdinaryQuota) {
+    let activeLimit: { type: LimitType; value: number | null } | null = null
+    if (settings.dailySubmissionLimit !== null && settings.dailySubmissionLimit !== undefined) {
+      activeLimit = { type: 'daily', value: settings.dailySubmissionLimit }
+    } else if (
+      settings.weeklySubmissionLimit !== null &&
+      settings.weeklySubmissionLimit !== undefined
+    ) {
+      activeLimit = { type: 'weekly', value: settings.weeklySubmissionLimit }
+    } else if (
+      settings.monthlySubmissionLimit !== null &&
+      settings.monthlySubmissionLimit !== undefined
+    ) {
+      activeLimit = { type: 'monthly', value: settings.monthlySubmissionLimit }
+    }
+
+    if (activeLimit?.value && activeLimit.value > 0) {
+      const { start, end } = getTimeRange(activeLimit.type)
+      canReturnQuota = song.createdAt >= start && song.createdAt <= end
     }
   }
 

--- a/server/services/cardCodeDeleteService.ts
+++ b/server/services/cardCodeDeleteService.ts
@@ -1,6 +1,7 @@
 import { inArray } from 'drizzle-orm'
+import { createError } from 'h3'
 import { db } from '~/drizzle/db'
-import { cardCodes } from '~/drizzle/schema'
+import { cardCodes, songs } from '~/drizzle/schema'
 
 export const deleteCardCodesByIds = async (ids: number[]) => {
   const normalizedIds = Array.from(new Set(ids.filter((id) => Number.isInteger(id) && id > 0)))
@@ -8,8 +9,31 @@ export const deleteCardCodesByIds = async (ids: number[]) => {
     return []
   }
 
-  return await db
-    .delete(cardCodes)
-    .where(inArray(cardCodes.id, normalizedIds))
-    .returning()
+  return await db.transaction(async (tx) => {
+    const existingRows = await tx
+      .select({ id: cardCodes.id })
+      .from(cardCodes)
+      .where(inArray(cardCodes.id, normalizedIds))
+      .for('update')
+
+    const existingIds = existingRows.map((row) => row.id)
+    if (!existingIds.length) {
+      return []
+    }
+
+    const referencedSongs = await tx
+      .select({ id: songs.id })
+      .from(songs)
+      .where(inArray(songs.cardCodeId, existingIds))
+      .limit(1)
+
+    if (referencedSongs.length > 0) {
+      throw createError({
+        statusCode: 409,
+        message: '已关联投稿的点歌券不能删除，请改为作废'
+      })
+    }
+
+    return await tx.delete(cardCodes).where(inArray(cardCodes.id, existingIds)).returning()
+  })
 }

--- a/server/services/songRequestService.ts
+++ b/server/services/songRequestService.ts
@@ -13,7 +13,10 @@ import {
 import { and, eq, gt, inArray, lt, lte, sql } from 'drizzle-orm'
 import { createError } from 'h3'
 import { createCollaborationInvitationNotification } from '~~/server/services/notificationService'
-import { isLimitReached } from '~~/server/utils/submissionLimit'
+import {
+  isCardCodeLimitBypassActive,
+  isLimitReached
+} from '~~/server/utils/submissionLimit'
 import { getClientIP } from '~~/server/utils/ip-utils'
 import { getBeijingTimeISOString } from '~/utils/timeUtils'
 import { z } from 'zod'
@@ -222,6 +225,7 @@ export async function requestSongForUser(event: any, user: SongRequestUser, body
     const isCardCodeEnabled = !!(
       systemSettingsData?.enableCardCodeRequests || systemSettingsData?.requireCardCodeForRequests
     )
+    const excludeCardCodeRequestsFromLimit = isCardCodeLimitBypassActive(systemSettingsData)
     if (requestBody.cardCode && requestBody.cardCode.trim() && !isCardCodeEnabled && !isAdmin) {
       throw createError({ statusCode: 400, message: '点歌券投稿功能未启用' })
     }
@@ -290,11 +294,23 @@ export async function requestSongForUser(event: any, user: SongRequestUser, body
       if (
         systemSettingsData?.enableSubmissionLimit &&
         !isAdmin &&
+        !(excludeCardCodeRequestsFromLimit && providedCardCodeId) &&
         effectiveLimit &&
         effectiveLimit > 0 &&
         limitType
       ) {
-        if (await isLimitReached(tx as any, user.id, limitType, effectiveLimit)) {
+        // 同一用户的限额检查必须串行，否则并发请求可能读取到相同计数并同时越过上限。
+        await tx
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.id, user.id))
+          .for('update')
+
+        if (
+          await isLimitReached(tx as any, user.id, limitType, effectiveLimit, {
+            excludeCardCodeRequests: excludeCardCodeRequestsFromLimit
+          })
+        ) {
           const labelMap: Record<string, string> = { daily: '每日', weekly: '每周', monthly: '每月' }
           const timeMap: Record<string, string> = { daily: '今日', weekly: '本周', monthly: '本月' }
 

--- a/server/utils/submissionLimit.ts
+++ b/server/utils/submissionLimit.ts
@@ -1,5 +1,5 @@
 import { db, songs } from '~/drizzle/db'
-import { and, eq, gte, lte, count } from 'drizzle-orm'
+import { and, count, eq, gte, isNull, lte } from 'drizzle-orm'
 import {
   getBeijingEndOfDay,
   getBeijingEndOfWeek,
@@ -10,6 +10,27 @@ import {
 } from '~/utils/timeUtils'
 
 export type LimitType = 'daily' | 'weekly' | 'monthly'
+
+type SubmissionCountOptions = {
+  excludeCardCodeRequests?: boolean
+}
+
+type CardCodeLimitSettings = {
+  enableSubmissionLimit?: boolean | null
+  enableCardCodeRequests?: boolean | null
+  requireCardCodeForRequests?: boolean | null
+  enableCardCodeLimitBypass?: boolean | null
+}
+
+export function isCardCodeLimitBypassActive(
+  settings: CardCodeLimitSettings | null | undefined
+): boolean {
+  return !!(
+    settings?.enableSubmissionLimit &&
+    settings.enableCardCodeLimitBypass &&
+    (settings.enableCardCodeRequests || settings.requireCardCodeForRequests)
+  )
+}
 
 /**
  * 获取指定限额类型的时间窗口（北京时间）
@@ -39,19 +60,19 @@ export function getTimeRange(type: LimitType) {
 }
 
 /**
- * 检查用户是否达到投稿限额
+ * 获取用户在指定周期内的投稿数量
  * @param dbOrTx 数据库实例或事务
  * @param userId 用户ID
  * @param type 限额类型
- * @param limit 限额数量
- * @returns boolean true 表示已达到限额（不允许继续投稿），false 表示未达到
+ * @param options 投稿统计选项
+ * @returns 投稿数量
  */
-export async function isLimitReached(
+export async function getSubmissionCount(
   dbOrTx: typeof db,
   userId: number,
   type: LimitType,
-  limit: number
-): Promise<boolean> {
+  options: SubmissionCountOptions = {}
+): Promise<number> {
   const { start, end } = getTimeRange(type)
 
   const [result] = await dbOrTx
@@ -61,9 +82,29 @@ export async function isLimitReached(
       and(
         eq(songs.requesterId, userId),
         gte(songs.createdAt, start),
-        lte(songs.createdAt, end)
+        lte(songs.createdAt, end),
+        options.excludeCardCodeRequests ? isNull(songs.cardCodeId) : undefined
       )
     )
 
-  return result.count >= limit
+  return result?.count || 0
+}
+
+/**
+ * 检查用户是否达到投稿限额
+ * @param dbOrTx 数据库实例或事务
+ * @param userId 用户ID
+ * @param type 限额类型
+ * @param limit 限额数量
+ * @param options 投稿统计选项
+ * @returns boolean true 表示已达到限额（不允许继续投稿），false 表示未达到
+ */
+export async function isLimitReached(
+  dbOrTx: typeof db,
+  userId: number,
+  type: LimitType,
+  limit: number,
+  options: SubmissionCountOptions = {}
+): Promise<boolean> {
+  return (await getSubmissionCount(dbOrTx, userId, type, options)) >= limit
 }

--- a/server/utils/system-settings-defaults.ts
+++ b/server/utils/system-settings-defaults.ts
@@ -29,6 +29,7 @@ export const SYSTEM_SETTINGS_DEFAULTS = {
   // 卡密点歌相关
   enableCardCodeRequests: false,
   requireCardCodeForRequests: false,
+  enableCardCodeLimitBypass: false,
   enableRequestTimeLimitation: false,
   forceBlockAllRequests: false,
   smtpEnabled: false,
@@ -69,6 +70,7 @@ export const PUBLIC_SETTINGS_FIELDS = [
   'enableSubmissionRemarks',
   'enableCardCodeRequests',
   'requireCardCodeForRequests',
+  'enableCardCodeLimitBypass',
   'enableRequestTimeLimitation',
   'forceBlockAllRequests',
   'smtpEnabled',

--- a/types/index.ts
+++ b/types/index.ts
@@ -140,6 +140,7 @@ export interface SystemSettings {
   enableSubmissionRemarks?: boolean
   enableCardCodeRequests?: boolean
   requireCardCodeForRequests?: boolean
+  enableCardCodeLimitBypass?: boolean
 }
 
 export interface RequestTime {


### PR DESCRIPTION
- 新增点歌券突破投稿限额配置开关
- 支持使用有效点歌券获得额外投稿次数
- 开启后点歌券投稿不占用普通投稿额度
- 支持按当前配置重新计算日、周、月投稿额度
- 在投稿页面展示点歌券额度规则和使用状态
- 支持撤回投稿时释放关联点歌券
- 禁止删除已关联投稿的点歌券
- 补充数据库迁移、备份恢复和旧数据库兼容支持

Closed #430