### PR TITLE
fix: 修复点歌投稿时期望播出时段参数校验类型错误导致的 400 问题

### DIFF
--- a/server/services/songRequestService.ts
+++ b/server/services/songRequestService.ts
@@ -37,7 +37,7 @@ const songRequestBodySchema = z.object({
   playUrl: z.string().trim().max(2000, '播放链接不能超过2000个字符').optional().nullable(),
   submissionNote: z.string().trim().max(300, '备注留言不能超过300个字符').optional().nullable(),
   submissionNotePublic: z.boolean().optional(),
-  preferredPlayTimeId: z.coerce.number().int().gt(0, '播出时段 ID 无效').optional().nullable(),
+  preferredPlayTimeId: z.number().int().gt(0, '播出时段 ID 无效').optional().nullable(),
   cardCode: z.string().trim().max(100, '点歌券不能超过100个字符').optional().nullable(),
   collaborators: z.array(z.union([z.string(), z.number()])).max(20, '联合投稿人不能超过20个').optional()
 })

--- a/server/services/songRequestService.ts
+++ b/server/services/songRequestService.ts
@@ -37,7 +37,7 @@ const songRequestBodySchema = z.object({
   playUrl: z.string().trim().max(2000, '播放链接不能超过2000个字符').optional().nullable(),
   submissionNote: z.string().trim().max(300, '备注留言不能超过300个字符').optional().nullable(),
   submissionNotePublic: z.boolean().optional(),
-  preferredPlayTimeId: z.string().uuid('播出时段 ID 无效').optional().nullable(),
+  preferredPlayTimeId: z.coerce.number().int().gt(0, '播出时段 ID 无效').optional().nullable(),
   cardCode: z.string().trim().max(100, '点歌券不能超过100个字符').optional().nullable(),
   collaborators: z.array(z.union([z.string(), z.number()])).max(20, '联合投稿人不能超过20个').optional()
 })


### PR DESCRIPTION
## 概要

  修复用户在点歌投稿时选择“期望播出时段”后，请求被后端以 400 拒绝的问题。

  问题原因并不是前端传参错误，而是后端 `/api/songs/request` 对 `preferredPlayTimeId` 的参数校验类型定义与实际数据模型不一致：当前系统中的播出时段ID使用的是数字主键，但后端错误地将其校验为 UUID 字符串，导致用户只要选择了播出时段，就会在参数校验阶段被拒绝。

  本次修改将后端对 `preferredPlayTimeId` 的校验调整为数值类型，并回滚此前错误的前端类型改动，使前后端与数据库字段定义重新保持一致。

  ## 问题原因

  当前系统中，播出时段 ID 的真实类型为数字：

  - 数据库 `playTimes.id` 为 `serial` 主键
  - 前端播出时段选项值使用的也是该数字 ID
  - 歌曲表中的 `preferredPlayTimeId` 同样为数字外键

  但后端 `/api/songs/request` 中的请求参数校验却将 `preferredPlayTimeId` 定义为 UUID 字符串，导致请求在参数校验阶段直接失败，出现类似报错：

  - `请求参数验证失败：播出时段 ID 无效`

  ## 修改内容

  - 修复 `server/services/songRequestService.ts` 中 `preferredPlayTimeId` 的校验规则，将其从 UUID 字符串校验调整为数值类型校验
  - 保持现有点歌提交流程与播出时段数据模型一致

  ## 影响文件

  - `server/services/songRequestService.ts`

  ## 修复前

  当用户选择“期望播出时段”后提交点歌请求时，请求中的 `preferredPlayTimeId` 会在后端参数校验阶段被错误地当作 UUID 校验，导致返回 400。

  ## 修复后

  当用户选择“期望播出时段”后提交点歌请求时，后端会按当前系统实际使用的数字型播出时段 ID 进行校验，请求可正常通过。