### PR TITLE
fix(auth): 编码聚合登录完整 state Cookie

### DIFF
--- a/server/api/auth/[provider]/callback.get.ts
+++ b/server/api/auth/[provider]/callback.get.ts
@@ -1,4 +1,9 @@
-import { parseState, getRedirectUri, getSafeOAuthReturnPath } from '~~/server/utils/oauth'
+import {
+  decodeOAuthStateCookie,
+  parseState,
+  getRedirectUri,
+  getSafeOAuthReturnPath
+} from '~~/server/utils/oauth'
 import { generateBindingToken } from '~~/server/utils/oauth-token'
 import { db, eq, users, userIdentities } from '~/drizzle/db'
 import { JWTEnhanced } from '~~/server/utils/jwt-enhanced'
@@ -70,7 +75,10 @@ export default defineEventHandler(async (event) => {
     if (!storedFullState || !storedCompactState || storedCompactState !== stateStr) {
       throw createError({ statusCode: 400, message: '聚合登录状态无效或已过期' })
     }
-    stateToVerify = storedFullState
+    stateToVerify = decodeOAuthStateCookie(storedFullState)
+    if (!stateToVerify) {
+      throw createError({ statusCode: 400, message: '聚合登录状态无效或已过期' })
+    }
   }
 
   const state = parseState(stateToVerify, origin, csrfCookie, stateSecret)

--- a/server/api/auth/[provider]/index.get.ts
+++ b/server/api/auth/[provider]/index.get.ts
@@ -1,4 +1,5 @@
 import {
+  encodeOAuthStateCookie,
   generateCompactOAuthState,
   generateState,
   getRedirectUri,
@@ -112,7 +113,7 @@ export default defineEventHandler(async (event) => {
       maxAge: 60 * 10,
       path: '/'
     }
-    setCookie(event, 'oauth_full_state', state, aggregateCookieOptions)
+    setCookie(event, 'oauth_full_state', encodeOAuthStateCookie(state), aggregateCookieOptions)
     setCookie(event, 'oauth_compact_state', authorizeState, aggregateCookieOptions)
   }
 

--- a/server/utils/oauth.ts
+++ b/server/utils/oauth.ts
@@ -30,16 +30,16 @@ const normalizePort = (url: URL): string => {
 
 const OAUTH_STATE_COOKIE_PREFIX = 'b64url:'
 
-// AES state 里可能包含 +、/、= 等字符，直接写入 Cookie 在部分代理/运行时中会被改写。
+// AES state 是标准 Base64，Cookie 中只需转换为 URL 安全格式以避免 +、/、= 被改写。
 export const encodeOAuthStateCookie = (state: string): string =>
-  `${OAUTH_STATE_COOKIE_PREFIX}${Buffer.from(state, 'utf8').toString('base64url')}`
+  `${OAUTH_STATE_COOKIE_PREFIX}${Buffer.from(state, 'base64').toString('base64url')}`
 
 export const decodeOAuthStateCookie = (state: string): string => {
   if (!state.startsWith(OAUTH_STATE_COOKIE_PREFIX)) {
     return state
   }
   try {
-    return Buffer.from(state.slice(OAUTH_STATE_COOKIE_PREFIX.length), 'base64url').toString('utf8')
+    return Buffer.from(state.slice(OAUTH_STATE_COOKIE_PREFIX.length), 'base64url').toString('base64')
   } catch {
     return ''
   }

--- a/server/utils/oauth.ts
+++ b/server/utils/oauth.ts
@@ -28,6 +28,23 @@ const normalizePort = (url: URL): string => {
   return ''
 }
 
+const OAUTH_STATE_COOKIE_PREFIX = 'b64url:'
+
+// AES state 里可能包含 +、/、= 等字符，直接写入 Cookie 在部分代理/运行时中会被改写。
+export const encodeOAuthStateCookie = (state: string): string =>
+  `${OAUTH_STATE_COOKIE_PREFIX}${Buffer.from(state, 'utf8').toString('base64url')}`
+
+export const decodeOAuthStateCookie = (state: string): string => {
+  if (!state.startsWith(OAUTH_STATE_COOKIE_PREFIX)) {
+    return state
+  }
+  try {
+    return Buffer.from(state.slice(OAUTH_STATE_COOKIE_PREFIX.length), 'base64url').toString('utf8')
+  } catch {
+    return ''
+  }
+}
+
 // 生成 OAuth 状态参数
 export const generateState = (
   targetOrigin: string,


### PR DESCRIPTION
- 修复聚合登录完整 AES state 直接写入 Cookie 后可能被代理/运行时改写的问题
- 将 `oauth_full_state` 以 `base64url` 包装后写入 Cookie，回调时再解码交给 `parseState`
- 保留对旧格式 Cookie 的兼容，避免旧会话直接解码失败
