### PR TITLE
feat(rateLimiter): 添加分布式限流功能并为点歌券验证实现限流

### DIFF
--- a/server/api/card-codes/validate.post.ts
+++ b/server/api/card-codes/validate.post.ts
@@ -1,12 +1,66 @@
 import { db } from '~/drizzle/db'
 import { cardCodes, systemSettings } from '~/drizzle/schema'
 import { eq } from 'drizzle-orm'
+import type { H3Event } from 'h3'
+import { getClientIP } from '~~/server/utils/ip-utils'
+import { checkDistributedRateLimit } from '~~/server/utils/rateLimiter'
+
+const USER_BURST_LIMIT = 5
+const USER_BURST_WINDOW_MS = 60 * 1000
+const USER_HOURLY_LIMIT = 20
+const USER_HOURLY_WINDOW_MS = 60 * 60 * 1000
+const IP_HOURLY_LIMIT = 100
+const IP_HOURLY_WINDOW_MS = 60 * 60 * 1000
+
+const enforceValidationRateLimit = async (event: H3Event, userId: number) => {
+  const clientIP = getClientIP(event)
+  const checks = [
+    checkDistributedRateLimit(
+      `card_code_validate_user_burst:${userId}`,
+      USER_BURST_LIMIT,
+      USER_BURST_WINDOW_MS
+    ),
+    checkDistributedRateLimit(
+      `card_code_validate_user_hourly:${userId}`,
+      USER_HOURLY_LIMIT,
+      USER_HOURLY_WINDOW_MS
+    )
+  ]
+
+  if (clientIP !== 'unknown') {
+    checks.push(
+      checkDistributedRateLimit(
+        `card_code_validate_ip_hourly:${clientIP}`,
+        IP_HOURLY_LIMIT,
+        IP_HOURLY_WINDOW_MS
+      )
+    )
+  }
+
+  const blockedChecks = (await Promise.all(checks)).filter((result) => !result.isAllowed)
+  if (!blockedChecks.length) return
+
+  const resetTime = Math.max(...blockedChecks.map((result) => result.resetTime))
+  const retryAfterSeconds = Math.max(1, Math.ceil((resetTime - Date.now()) / 1000))
+  const waitText =
+    retryAfterSeconds >= 60
+      ? `${Math.ceil(retryAfterSeconds / 60)} 分钟`
+      : `${retryAfterSeconds} 秒`
+
+  setResponseHeader(event, 'Retry-After', String(retryAfterSeconds))
+  throw createError({
+    statusCode: 429,
+    message: `点歌券验证请求过于频繁，请等待 ${waitText} 后再试`
+  })
+}
 
 export default defineEventHandler(async (event) => {
   const user = event.context.user
   if (!user) {
     throw createError({ statusCode: 401, message: '需要登录才能验证点歌券' })
   }
+
+  await enforceValidationRateLimit(event, user.id)
 
   const body = (await readBody(event)) || {}
   const code = typeof body.cardCode === 'string' ? body.cardCode.trim().toUpperCase() : ''

--- a/server/api/card-codes/validate.post.ts
+++ b/server/api/card-codes/validate.post.ts
@@ -1,9 +1,10 @@
 import { db } from '~/drizzle/db'
 import { cardCodes, systemSettings } from '~/drizzle/schema'
 import { eq } from 'drizzle-orm'
-import type { H3Event } from 'h3'
+import { setResponseHeader, type H3Event } from 'h3'
 import { getClientIP } from '~~/server/utils/ip-utils'
 import { checkDistributedRateLimit } from '~~/server/utils/rateLimiter'
+import { getServerTimestamp } from '~~/server/utils/serverTime'
 
 const USER_BURST_LIMIT = 5
 const USER_BURST_WINDOW_MS = 60 * 1000
@@ -12,36 +13,8 @@ const USER_HOURLY_WINDOW_MS = 60 * 60 * 1000
 const IP_HOURLY_LIMIT = 100
 const IP_HOURLY_WINDOW_MS = 60 * 60 * 1000
 
-const enforceValidationRateLimit = async (event: H3Event, userId: number) => {
-  const clientIP = getClientIP(event)
-  const checks = [
-    checkDistributedRateLimit(
-      `card_code_validate_user_burst:${userId}`,
-      USER_BURST_LIMIT,
-      USER_BURST_WINDOW_MS
-    ),
-    checkDistributedRateLimit(
-      `card_code_validate_user_hourly:${userId}`,
-      USER_HOURLY_LIMIT,
-      USER_HOURLY_WINDOW_MS
-    )
-  ]
-
-  if (clientIP !== 'unknown') {
-    checks.push(
-      checkDistributedRateLimit(
-        `card_code_validate_ip_hourly:${clientIP}`,
-        IP_HOURLY_LIMIT,
-        IP_HOURLY_WINDOW_MS
-      )
-    )
-  }
-
-  const blockedChecks = (await Promise.all(checks)).filter((result) => !result.isAllowed)
-  if (!blockedChecks.length) return
-
-  const resetTime = Math.max(...blockedChecks.map((result) => result.resetTime))
-  const retryAfterSeconds = Math.max(1, Math.ceil((resetTime - Date.now()) / 1000))
+const throwRateLimitError = (event: H3Event, resetTime: number): never => {
+  const retryAfterSeconds = Math.max(1, Math.ceil((resetTime - getServerTimestamp()) / 1000))
   const waitText =
     retryAfterSeconds >= 60
       ? `${Math.ceil(retryAfterSeconds / 60)} 分钟`
@@ -52,6 +25,39 @@ const enforceValidationRateLimit = async (event: H3Event, userId: number) => {
     statusCode: 429,
     message: `点歌券验证请求过于频繁，请等待 ${waitText} 后再试`
   })
+}
+
+const enforceValidationRateLimit = async (event: H3Event, userId: number) => {
+  const clientIP = getClientIP(event)
+
+  const burstResult = await checkDistributedRateLimit(
+    `card_code_validate_user_burst:${userId}`,
+    USER_BURST_LIMIT,
+    USER_BURST_WINDOW_MS
+  )
+  if (!burstResult.isAllowed) {
+    throwRateLimitError(event, burstResult.resetTime)
+  }
+
+  const hourlyResult = await checkDistributedRateLimit(
+    `card_code_validate_user_hourly:${userId}`,
+    USER_HOURLY_LIMIT,
+    USER_HOURLY_WINDOW_MS
+  )
+  if (!hourlyResult.isAllowed) {
+    throwRateLimitError(event, hourlyResult.resetTime)
+  }
+
+  if (clientIP !== 'unknown') {
+    const ipResult = await checkDistributedRateLimit(
+      `card_code_validate_ip_hourly:${clientIP}`,
+      IP_HOURLY_LIMIT,
+      IP_HOURLY_WINDOW_MS
+    )
+    if (!ipResult.isAllowed) {
+      throwRateLimitError(event, ipResult.resetTime)
+    }
+  }
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/utils/rateLimiter.ts
+++ b/server/utils/rateLimiter.ts
@@ -10,6 +10,15 @@ interface RateLimitRecord {
 
 const MAX_STORE_SIZE = 10000 // 最大允许存储的IP记录数
 const store = new Map<string, RateLimitRecord>()
+const DISTRIBUTED_RATE_LIMIT_SCRIPT = `
+local count = redis.call('INCR', KEYS[1])
+local ttl = redis.call('PTTL', KEYS[1])
+if count == 1 or ttl < 0 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+  ttl = tonumber(ARGV[1])
+end
+return { count, ttl }
+`
 
 /**
  * 检查并增加限流计数
@@ -64,12 +73,18 @@ export async function checkDistributedRateLimit(
 
     if (client) {
       const redisKey = `rate_limit:${key}`
-      const count = await client.incr(redisKey)
-      let ttl = await client.pTTL(redisKey)
+      const result = await client.eval(DISTRIBUTED_RATE_LIMIT_SCRIPT, {
+        keys: [redisKey],
+        arguments: [String(windowMs)]
+      })
+      if (!Array.isArray(result) || result.length < 2) {
+        throw new Error('Redis 限流脚本返回了无效结果')
+      }
 
-      if (count === 1 || ttl < 0) {
-        await client.pExpire(redisKey, windowMs)
-        ttl = windowMs
+      const count = Number(result[0])
+      const ttl = Math.max(0, Number(result[1]))
+      if (!Number.isFinite(count) || !Number.isFinite(ttl)) {
+        throw new Error('Redis 限流脚本返回了无效计数')
       }
 
       return {

--- a/server/utils/rateLimiter.ts
+++ b/server/utils/rateLimiter.ts
@@ -18,7 +18,11 @@ const store = new Map<string, RateLimitRecord>()
  * @param windowMs 时间窗口大小（毫秒）
  * @returns { isAllowed: boolean, remaining: number, resetTime: number }
  */
-export function checkRateLimit(key: string, limit: number, windowMs: number): { isAllowed: boolean, remaining: number, resetTime: number } {
+export function checkRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number
+): { isAllowed: boolean; remaining: number; resetTime: number } {
   const now = getServerTimestamp()
   let record = store.get(key)
 
@@ -46,6 +50,42 @@ export function checkRateLimit(key: string, limit: number, windowMs: number): { 
 }
 
 /**
+ * 优先使用 Redis 执行跨实例限流，Redis 不可用时回退到当前进程内存。
+ * 适用于需要在多实例或 Serverless 环境中保持一致计数的敏感接口。
+ */
+export async function checkDistributedRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number
+): Promise<{ isAllowed: boolean; remaining: number; resetTime: number }> {
+  try {
+    const { getRedisClient } = await import('./redis')
+    const client = getRedisClient()
+
+    if (client) {
+      const redisKey = `rate_limit:${key}`
+      const count = await client.incr(redisKey)
+      let ttl = await client.pTTL(redisKey)
+
+      if (count === 1 || ttl < 0) {
+        await client.pExpire(redisKey, windowMs)
+        ttl = windowMs
+      }
+
+      return {
+        isAllowed: count <= limit,
+        remaining: Math.max(0, limit - count),
+        resetTime: getServerTimestamp() + ttl
+      }
+    }
+  } catch (error) {
+    console.error('[RateLimit] Redis 限流失败，已回退到内存限流', error)
+  }
+
+  return checkRateLimit(key, limit, windowMs)
+}
+
+/**
  * 清理过期的限流记录
  * @param force 如果为 true，在没有过期数据时也会强制删除最旧的记录
  */
@@ -65,7 +105,7 @@ export function cleanupRateLimits(force = false) {
   if (force && deletedCount === 0 && store.size > 0) {
     const itemsToDelete = Math.ceil(MAX_STORE_SIZE * 0.1)
     const keys = store.keys()
-    
+
     for (let i = 0; i < itemsToDelete; i++) {
       const key = keys.next().value
       if (key !== undefined) {

--- a/server/utils/rateLimiter.ts
+++ b/server/utils/rateLimiter.ts
@@ -8,8 +8,13 @@ interface RateLimitRecord {
   resetTime: number
 }
 
+type RedisClientGetter = (typeof import('./redis'))['getRedisClient']
+
 const MAX_STORE_SIZE = 10000 // 最大允许存储的IP记录数
+const REDIS_ERROR_LOG_INTERVAL_MS = 60 * 1000
 const store = new Map<string, RateLimitRecord>()
+let getRedisClientFn: RedisClientGetter | null = null
+let lastRedisErrorLogTime = 0
 const DISTRIBUTED_RATE_LIMIT_SCRIPT = `
 local count = redis.call('INCR', KEYS[1])
 local ttl = redis.call('PTTL', KEYS[1])
@@ -68,8 +73,12 @@ export async function checkDistributedRateLimit(
   windowMs: number
 ): Promise<{ isAllowed: boolean; remaining: number; resetTime: number }> {
   try {
-    const { getRedisClient } = await import('./redis')
-    const client = getRedisClient()
+    if (!getRedisClientFn) {
+      const redisModule = await import('./redis')
+      getRedisClientFn = redisModule.getRedisClient
+    }
+
+    const client = getRedisClientFn()
 
     if (client) {
       const redisKey = `rate_limit:${key}`
@@ -94,7 +103,11 @@ export async function checkDistributedRateLimit(
       }
     }
   } catch (error) {
-    console.error('[RateLimit] Redis 限流失败，已回退到内存限流', error)
+    const now = Date.now()
+    if (now - lastRedisErrorLogTime >= REDIS_ERROR_LOG_INTERVAL_MS) {
+      console.error('[RateLimit] Redis 限流失败，已回退到内存限流', error)
+      lastRedisErrorLogTime = now
+    }
   }
 
   return checkRateLimit(key, limit, windowMs)


### PR DESCRIPTION
- 在 rateLimiter 中添加 checkDistributedRateLimit 函数，支持 Redis 分布式限流
- 实现 Redis 限流回退到内存限流的容错机制
- 为点歌券验证接口添加多层次限流策略（用户突发、用户小时、IP 小时）
- 集成客户端 IP 获取和限流检查逻辑
- 添加限流触发时的重试时间和错误响应处理

Closed #493