### PR TITLE
fix(deploy): 修复 EdgeOne 构建无法解析 @nuxt/kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@lucide/vue": "^1.25.0",
     "@neteasecloudmusicapienhanced/api": "^4.37.0",
     "@netlify/functions": "^2.8.2",
+    "@nuxt/kit": "4.5.0",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@pixi/app": "^7.4.3",
     "@pixi/core": "^7.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@netlify/functions':
         specifier: ^2.8.2
         version: 2.8.2
+      '@nuxt/kit':
+        specifier: 4.5.0
+        version: 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.139.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))
       '@nuxtjs/tailwindcss':
         specifier: ^6.14.0
         version: 6.14.0(magicast@0.5.3)(tsx@4.23.1)(yaml@2.9.0)


### PR DESCRIPTION
## 变更说明

修复 EdgeOne Pages 部署时无法解析 `@nuxt/kit`，导致 Nuxt 构建失败的问题。

## 问题原因

提交 `5450399` 将 Nuxt 从 `4.4.8` 升级至 `4.5.0`，但项目未同步声明 `@nuxt/kit` 直接依赖。

EdgeOne 构建过程中会注入 `.edgeone-nitro-config.mjs`，该模块需要从项目根目录加载 `@nuxt/kit`。由于 pnpm 使用严格依赖隔离，无法直接访问 Nuxt 的传递依赖，最终出现：

```text
Cannot find module '@nuxt/kit'
```

## 修改内容

- 添加直接依赖 `@nuxt/kit@4.5.0`
- 同步更新 `pnpm-lock.yaml`
- 保持 `@nuxt/kit` 与当前 Nuxt 版本一致

## 验证结果

- `pnpm install --frozen-lockfile` 通过
- 项目根目录可正常导入 `@nuxt/kit`
- Nuxt 生产环境完整构建通过
- EdgeOne 报错对应的模块解析问题已消除