### PR TITLE
fix(package): 添加 pnpm overrides 锁定 h3 v1 解决 devframe peer dep 冲突

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
     "node": ">=18.20.0",
     "pnpm": ">=10.0.0"
   },
+  "pnpm": {
+    "overrides": {
+      "h3": "1.15.11"
+    }
+  },
   "devDependencies": {
     "@nuxt/eslint": "^1.16.0",
     "@nuxt/kit": "4.5.0",


### PR DESCRIPTION
有的依赖使用了 h3 v2，但 v2 没有 sendError ，导致运行报错