### PR TITLE
删除MetingAPI请求中加在baseUrl后面的"/"

### DIFF
--- a/app/composables/useMusicSources.ts
+++ b/app/composables/useMusicSources.ts
@@ -374,7 +374,7 @@ export const useMusicSources = () => {
     error?: string
   }> => {
     try {
-      const metingUrl = `${source.baseUrl}/?server=netease&type=song&id=${id}`
+      const metingUrl = `${source.baseUrl}?server=netease&type=song&id=${id}`
 
       const response = await $fetch(metingUrl, {
         timeout: source.timeout || 8000,
@@ -2061,7 +2061,7 @@ export const useMusicSources = () => {
                 url = songInfo.data.url
               } else {
                 // 如果获取歌曲信息失败，直接使用 URL 类型的 API
-                const metingUrl = `${source.baseUrl}/?server=netease&type=url&id=${idParam}`
+                const metingUrl = `${source.baseUrl}?server=netease&type=url&id=${idParam}`
 
                 // 对于 Meting API，我们需要处理重定向
                 const response = await fetch(metingUrl, {


### PR DESCRIPTION
删除"/"以支持更多的MetingAPI版本

部分MetingAPI分支[xizeyoupan/Meting-API (Vercel部署版本)]的api请求是/api?server=netease&type=song&id=songid且不能写为/api/?

经过测试，普通MetingAPI版本[injahow/meting-api]的api请求/meting/?和/meting?效果相同没有影响

删除"/"后可2种MetingAPI均可正常使用