### PR TITLE
feat(meting-api): 去掉默认加在baseUrl后的"/"以支持更多MetingAPI分支

### DIFF
--- a/app/composables/useMusicSources.ts
+++ b/app/composables/useMusicSources.ts
@@ -374,7 +374,7 @@ export const useMusicSources = () => {
     error?: string
   }> => {
     try {
-      const metingUrl = `${source.baseUrl}/?server=netease&type=song&id=${id}`
+      const metingUrl = `${source.baseUrl}?server=netease&type=song&id=${id}`
 
       const response = await $fetch(metingUrl, {
         timeout: source.timeout || 8000,
@@ -2061,7 +2061,7 @@ export const useMusicSources = () => {
                 url = songInfo.data.url
               } else {
                 // 如果获取歌曲信息失败，直接使用 URL 类型的 API
-                const metingUrl = `${source.baseUrl}/?server=netease&type=url&id=${idParam}`
+                const metingUrl = `${source.baseUrl}?server=netease&type=url&id=${idParam}`
 
                 // 对于 Meting API，我们需要处理重定向
                 const response = await fetch(metingUrl, {

--- a/app/utils/musicSources.ts
+++ b/app/utils/musicSources.ts
@@ -168,7 +168,7 @@ export const MUSIC_SOURCE_CONFIG: MusicSourceConfig = {
     {
       id: 'meting-1',
       name: 'Meting API 备用源1',
-      baseUrl: 'https://api.qijieya.cn/meting',
+      baseUrl: 'https://api.qijieya.cn/meting/',
       priority: 5,
       enabled: true,
       timeout: 8000,


### PR DESCRIPTION
删除"/"以支持更多的MetingAPI版本

- [xizeyoupan/Meting-API (Vercel部署版本)]的api请求是/api?server=netease&type=song&id=songid

- [injahow/meting-api]的api请求是/meting/?server=netease&type=song&id=songid

更改后baseUrl写法: 

- [xizeyoupan/Meting-API (Vercel部署版本)] https://api.example.com/api

- [injahow/meting-api] https://api.example.com/meting/