### PR TITLE
feat(site-config): 支持首页学校 Logo 深色和浅色模式分离配置

### DIFF
--- a/app/components/Admin/SiteConfigManager.vue
+++ b/app/components/Admin/SiteConfigManager.vue
@@ -119,10 +119,20 @@
           <div>
             <label :class="labelClass">{{ locale.schoolLogoHome }}</label>
             <input
-              v-model="formData.schoolLogoHomeUrl"
+              v-model="formData.schoolLogoHomeDarkUrl"
               type="text"
               :placeholder="locale.schoolLogoHomePlaceholder"
               :class="inputClass"
+            />
+          </div>
+          <div>
+            <label :class="labelClass">{{ locale.schoolLogoHomeLight }}</label>
+            <input
+              v-model="formData.schoolLogoHomeLightUrl"
+              type="text"
+              :disabled="!String(formData.schoolLogoHomeDarkUrl || '').trim()"
+              :placeholder="locale.schoolLogoHomeLightPlaceholder"
+              :class="[inputClass, 'disabled:cursor-not-allowed disabled:opacity-50']"
             />
           </div>
           <div>
@@ -568,7 +578,7 @@ import {
 } from '@lucide/vue'
 import AppSpinner from '~/components/UI/Common/AppSpinner.vue'
 import { useToast } from '~/composables/useToast'
-import { useSiteConfig } from '~/composables/useSiteConfig'
+import { joinThemeLogoUrl, splitThemeLogoUrl, useSiteConfig } from '~/composables/useSiteConfig'
 import { useLocale } from '~/utils/locale'
 import { renderMarkdown } from '~/utils/markdown'
 import { getAggregateOAuthLoginTypesOrDefault } from '~/utils/oauth'
@@ -597,7 +607,8 @@ const defaultSubmissionGuidelines = computed(() => locale.value?.defaultSubmissi
 const formData = ref({
   siteTitle: '',
   siteLogoUrl: '',
-  schoolLogoHomeUrl: '',
+  schoolLogoHomeDarkUrl: '',
+  schoolLogoHomeLightUrl: '',
   schoolLogoPrintUrl: '',
   siteDescription: '',
   submissionGuidelines: '',
@@ -817,10 +828,12 @@ const loadConfig = async () => {
 
     syncActiveLimitTab(data)
 
+    const schoolLogoHome = splitThemeLogoUrl(data.schoolLogoHomeUrl)
     formData.value = {
       siteTitle: data.siteTitle || '',
       siteLogoUrl: data.siteLogoUrl || '',
-      schoolLogoHomeUrl: data.schoolLogoHomeUrl || '',
+      schoolLogoHomeDarkUrl: schoolLogoHome.dark,
+      schoolLogoHomeLightUrl: schoolLogoHome.light,
       schoolLogoPrintUrl: data.schoolLogoPrintUrl || '',
       siteDescription: data.siteDescription || '',
       submissionGuidelines: data.submissionGuidelines || defaultSubmissionGuidelines.value,
@@ -894,8 +907,16 @@ const loadConfig = async () => {
 const saveConfig = async () => {
   try {
     saving.value = true
+    const schoolLogoHomeDarkUrl = (formData.value.schoolLogoHomeDarkUrl || '').trim()
+    const schoolLogoHomeLightUrl = schoolLogoHomeDarkUrl
+      ? (formData.value.schoolLogoHomeLightUrl || '').trim()
+      : ''
     const configToSave = {
       ...formData.value,
+      schoolLogoHomeUrl: joinThemeLogoUrl(
+        schoolLogoHomeDarkUrl,
+        schoolLogoHomeLightUrl
+      ),
       siteTitle: (formData.value.siteTitle || '').trim() || locale.value?.defaultSiteTitle || 'VoiceHub',
       siteLogoUrl: (formData.value.siteLogoUrl || '').trim() || '/favicon.ico',
       submissionGuidelines:
@@ -908,6 +929,8 @@ const saveConfig = async () => {
       monthlySubmissionLimit:
         activeLimitTab.value === 'monthly' ? formData.value.monthlySubmissionLimit : null
     }
+    delete configToSave.schoolLogoHomeDarkUrl
+    delete configToSave.schoolLogoHomeLightUrl
 
     const response = await fetch('/api/admin/system-settings', {
       method: 'POST',
@@ -939,7 +962,11 @@ const saveConfig = async () => {
     }
 
     saveSuccess.value = true
-    formData.value = { ...configToSave }
+    formData.value = {
+      ...formData.value,
+      siteTitle: configToSave.siteTitle,
+      siteLogoUrl: configToSave.siteLogoUrl
+    }
     originalData.value = JSON.parse(JSON.stringify(formData.value))
     localStorage.setItem('voicehub.telemetryEnabled', configToSave.telemetryEnabled ? 'true' : 'false')
     // 刷新前端模块级缓存，避免首页等页面继续使用旧配置

--- a/app/composables/useSiteConfig.js
+++ b/app/composables/useSiteConfig.js
@@ -1,5 +1,32 @@
 import { computed, ref, readonly } from 'vue'
 import { getAggregateOAuthLoginTypesOrDefault, getProviderDisplayName } from '~/utils/oauth'
+import { useTheme } from '~/composables/useTheme'
+
+const THEME_LOGO_SEPARATOR = '||'
+
+// 兼容旧配置：没有分隔符时，同一个地址用于两种主题。
+export const splitThemeLogoUrl = (value) => {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+  if (!normalized) return { dark: '', light: '' }
+
+  const separatorIndex = normalized.indexOf(THEME_LOGO_SEPARATOR)
+  if (separatorIndex < 0) return { dark: normalized, light: normalized }
+
+  const dark = normalized.slice(0, separatorIndex).trim()
+  const light = normalized.slice(separatorIndex + THEME_LOGO_SEPARATOR.length).trim()
+  return {
+    dark: dark || light,
+    light: light || dark
+  }
+}
+
+export const joinThemeLogoUrl = (dark, light) => {
+  const normalizedDark = typeof dark === 'string' ? dark.trim() : ''
+  const normalizedLight = typeof light === 'string' ? light.trim() : ''
+  if (!normalizedDark && !normalizedLight) return ''
+  if (!normalizedLight || normalizedLight === normalizedDark) return normalizedDark || normalizedLight
+  return `${normalizedDark}||${normalizedLight}`
+}
 
 const defaultSubmissionGuidelines = `1. 投稿时无需加入书名号
 2. 除DJ外，其他类型歌曲均接收（包括小语种）
@@ -52,6 +79,7 @@ const getImageDisplayUrl = (url) => {
 }
 
 export const useSiteConfig = () => {
+  const { isDark } = useTheme()
   // 获取站点配置
   const fetchSiteConfig = async () => {
     if (isLoading.value) return
@@ -108,7 +136,10 @@ export const useSiteConfig = () => {
   // 计算属性
   const siteTitle = computed(() => siteConfig.value.siteTitle || '校园广播站点歌系统')
   const logoUrl = computed(() => siteConfig.value.siteLogoUrl || '/favicon.ico')
-  const schoolLogoHomeUrl = computed(() => siteConfig.value.schoolLogoHomeUrl || '')
+  const schoolLogoHomeUrl = computed(() => {
+    const logos = splitThemeLogoUrl(siteConfig.value.schoolLogoHomeUrl)
+    return (isDark.value ? logos.dark : logos.light) || logos.dark || logos.light || ''
+  })
   const schoolLogoPrintUrl = computed(() => siteConfig.value.schoolLogoPrintUrl || '')
   const schoolLogoHomeDisplayUrl = computed(() => getImageDisplayUrl(schoolLogoHomeUrl.value))
   const schoolLogoPrintDisplayUrl = computed(() => getImageDisplayUrl(schoolLogoPrintUrl.value))

--- a/app/composables/useSiteConfig.js
+++ b/app/composables/useSiteConfig.js
@@ -4,13 +4,13 @@ import { useTheme } from '~/composables/useTheme'
 
 const THEME_LOGO_SEPARATOR = '||'
 
-// 兼容旧配置：没有分隔符时，同一个地址用于两种主题。
+// 兼容旧配置：没有分隔符时，地址只归入深色；浅色运行时回退到深色。
 export const splitThemeLogoUrl = (value) => {
   const normalized = typeof value === 'string' ? value.trim() : ''
   if (!normalized) return { dark: '', light: '' }
 
   const separatorIndex = normalized.indexOf(THEME_LOGO_SEPARATOR)
-  if (separatorIndex < 0) return { dark: normalized, light: normalized }
+  if (separatorIndex < 0) return { dark: normalized, light: '' }
 
   const dark = normalized.slice(0, separatorIndex).trim()
   const light = normalized.slice(separatorIndex + THEME_LOGO_SEPARATOR.length).trim()

--- a/app/utils/locale/en-US.ts
+++ b/app/utils/locale/en-US.ts
@@ -22,8 +22,10 @@ export const siteConfig = {
   visualIdentity: 'Visual Identity',
   siteLogoUrl: 'Site Logo URL',
   siteLogoPlaceholder: 'Enter the logo image URL',
-  schoolLogoHome: 'Home School Logo URL (Large)',
-  schoolLogoHomePlaceholder: 'Enter the home school logo URL',
+  schoolLogoHome: 'Home School Logo URL (Dark)',
+  schoolLogoHomePlaceholder: 'Enter the dark-mode school logo URL first',
+  schoolLogoHomeLight: 'Home School Logo URL (Light)',
+  schoolLogoHomeLightPlaceholder: 'Enter the light-mode school logo URL',
   schoolLogoPrint: 'Print Schedule Logo URL (Small)',
   schoolLogoPrintPlaceholder: 'Enter the print page school logo URL',
 

--- a/app/utils/locale/zh-CN.ts
+++ b/app/utils/locale/zh-CN.ts
@@ -29,8 +29,10 @@ export const siteConfig = {
   visualIdentity: '视觉识别',
   siteLogoUrl: '站点 Logo URL',
   siteLogoPlaceholder: '请输入Logo图片URL',
-  schoolLogoHome: '首页学校 Logo URL (大尺寸)',
-  schoolLogoHomePlaceholder: '请输入首页学校Logo URL',
+  schoolLogoHome: '首页学校 Logo URL（深色模式）',
+  schoolLogoHomePlaceholder: '请先输入深色模式学校 Logo URL',
+  schoolLogoHomeLight: '首页学校 Logo URL（浅色模式）',
+  schoolLogoHomeLightPlaceholder: '请输入浅色模式学校 Logo URL',
   schoolLogoPrint: '打印排期 Logo URL (小尺寸)',
   schoolLogoPrintPlaceholder: '请输入打印页学校Logo URL',
 


### PR DESCRIPTION
- 在语言包中新增浅色模式学校 Logo 相关文案
- SiteConfigManager 组件新增浅色模式 Logo 输入框及联动禁用逻辑
- useSiteConfig 新增 splitThemeLogoUrl 和 joinThemeLogoUrl 方法处理双模式 Logo 地址
- 页面加载时拆分合并双模式 Logo 地址，提交保存时合并存储
- 结合当前主题动态选择展示深色或浅色 Logo 地址
- 保持兼容性，旧格式的单一 Logo 地址继续生效