### PR TITLE
fix(smtp): 修复邮件配置刷新页面后 535 认证失败

### DIFF
--- a/server/api/admin/backup/restore.post.ts
+++ b/server/api/admin/backup/restore.post.ts
@@ -2646,7 +2646,8 @@ export default defineEventHandler(async (event) => {
 
     try {
       const smtpService = SmtpService.getInstance()
-      const initialized = await smtpService.initializeSmtpConfig()
+      // 强制重载：备份恢复会替换 SMTP 配置，transporter 已存在时默认早退会导致仍用旧凭据
+      const initialized = await smtpService.initializeSmtpConfig(true)
       if (!initialized) {
         restoreResults.details.warnings = restoreResults.details.warnings || []
         restoreResults.details.warnings.push('SMTP未启用或配置不完整，SMTP实例已重置')

--- a/server/api/admin/smtp/reload.post.ts
+++ b/server/api/admin/smtp/reload.post.ts
@@ -19,7 +19,8 @@ export default defineEventHandler(async (event) => {
 
   try {
     const smtpService = SmtpService.getInstance()
-    const initialized = await smtpService.initializeSmtpConfig()
+    // 强制重载：transporter 已存在时默认早退，无法刷新已变更的配置
+    const initialized = await smtpService.initializeSmtpConfig(true)
 
     return {
       success: true,

--- a/server/api/admin/smtp/test-connection.post.ts
+++ b/server/api/admin/smtp/test-connection.post.ts
@@ -1,4 +1,6 @@
 import { SmtpService } from '~~/server/services/smtpService'
+import { getSystemSettingsCached } from '~~/server/utils/system-settings-helper'
+import { SMTP_PASSWORD_MASK } from '~~/server/api/admin/system-settings/secretMask'
 
 export default defineEventHandler(async (event) => {
   // 检查请求方法
@@ -52,10 +54,11 @@ export default defineEventHandler(async (event) => {
     const originalTransporter = smtpService.transporter
 
     try {
-      // 如果密码是掩码，则使用原始配置中的密码
+      // 客户端仅持有掩码时，从数据库读取真实密码，避免依赖内存单例的初始化状态（冷启动竞态/陈旧配置）
+      const storedSettings = await getSystemSettingsCached()
       const testPassword =
-        body.smtpPassword === '****************'
-          ? originalConfig?.auth?.pass || body.smtpPassword
+        body.smtpPassword === SMTP_PASSWORD_MASK
+          ? storedSettings?.smtpPassword || ''
           : body.smtpPassword
 
       // 设置测试配置

--- a/server/api/admin/smtp/test-email.post.ts
+++ b/server/api/admin/smtp/test-email.post.ts
@@ -1,5 +1,7 @@
 import { SmtpService } from '~~/server/services/smtpService'
 import { getClientIP } from '~~/server/utils/ip-utils'
+import { getSystemSettingsCached } from '~~/server/utils/system-settings-helper'
+import { SMTP_PASSWORD_MASK } from '~~/server/api/admin/system-settings/secretMask'
 
 export default defineEventHandler(async (event) => {
   // 检查请求方法
@@ -60,10 +62,11 @@ export default defineEventHandler(async (event) => {
     const originalTransporter = smtpService.transporter
 
     try {
-      // 如果密码是掩码，则使用原始配置中的密码
+      // 客户端仅持有掩码时，从数据库读取真实密码，避免依赖内存单例的初始化状态（冷启动竞态/陈旧配置）
+      const storedSettings = await getSystemSettingsCached()
       const testPassword =
-        body.smtpPassword === '****************'
-          ? originalConfig?.auth?.pass || body.smtpPassword
+        body.smtpPassword === SMTP_PASSWORD_MASK
+          ? storedSettings?.smtpPassword || ''
           : body.smtpPassword
 
       // 设置测试配置

--- a/server/api/admin/system-settings/index.post.ts
+++ b/server/api/admin/system-settings/index.post.ts
@@ -1072,7 +1072,8 @@ export default defineEventHandler(async (event) => {
 
     try {
       const { SmtpService } = await import('~~/server/services/smtpService')
-      await SmtpService.getInstance().initializeSmtpConfig()
+      // 强制刷新：transporter 已存在时默认早退，改密后内存单例仍持有旧凭据
+      await SmtpService.getInstance().initializeSmtpConfig(true)
       console.log('[SMTP] SMTP配置已重新加载（更新系统设置）')
     } catch (smtpError) {
       console.warn('[SMTP] SMTP配置重载失败:', smtpError)


### PR DESCRIPTION
## 问题描述

在管理后台配置好 SMTP 授权码并保存后，**刷新页面之前**测试邮件可以正常发送；**刷新页面之后**再点击"发送测试邮件"，提示 `Invalid login: 535 5.7.8 Authentication credentials invalid`。

## 根因分析

1. **密码掩码设计**：`GET /api/admin/system-settings` 会把 `smtpPassword` 掩码为 `'****************'` 返回给客户端（`secretMask.ts`），避免明文密钥泄漏到浏览器。因此刷新页面后，表单中的密码字段只剩掩码。

2. **测试接口的掩码回退依赖内存单例**（核心问题）：`test-email.post.ts` 与 `test-connection.post.ts` 收到掩码时，尝试从 `SmtpService` 内存单例的 `smtpConfig.auth.pass` 找回真实密码。但该单例配置**不可靠**：
   - **冷启动竞态**：`SmtpService.getInstance()` 首次创建实例时，`initializeSmtpConfig()` 异步执行且不等待（`smtpService.ts` 第 216 行），测试接口紧接着同步读取 `smtpConfig`，此时配置仍为 `null`，最终把掩码当作密码发送给 SMTP 服务器 → 535。
   - **陈旧配置**：`initializeSmtpConfig()` 在 transporter 已存在时直接早退（第 254-256 行），而保存配置、手动重载均未传 `forceRefresh=true`，修改授权码后单例仍持有旧凭据。

3. **对照**：备份模块的 `test-email.post.ts` 与 `autoBackupService.ts` 都是直接从数据库读取真实密码（`getSystemSettingsCached()`），行为正确；只有 SMTP 管理器测试接口依赖了不可靠的内存单例。

## 修复内容

| 文件 | 修改 |
|---|---|
| `server/api/admin/smtp/test-email.post.ts` | 收到掩码时从数据库读取真实密码（`getSystemSettingsCached()`），不再依赖内存单例 |
| `server/api/admin/smtp/test-connection.post.ts` | 同上 |
| `server/api/admin/smtp/reload.post.ts` | `initializeSmtpConfig(true)` 强制重载，修复"重载"按钮在 transporter 已存在时不生效的问题 |
| `server/api/admin/system-settings/index.post.ts` | 保存 SMTP 配置后 `initializeSmtpConfig(true)` 强制刷新，避免真实通知邮件继续使用旧凭据 |
| `server/api/admin/backup/restore.post.ts` | 备份恢复后 `initializeSmtpConfig(true)` 强制重载，避免恢复出的新配置不生效 |

## 本地验证（Windows 11，Mailpit 认证模式）

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 掩码测试邮件（模拟刷新页面） | ❌ `Invalid login: 535` | ✅ 发送成功 |
| 真实密码测试（基线对照） | ✅ 成功 | ✅ 成功 |
| 冷启动（重启后立即测试，单例未初始化） | —（不可靠） | ✅ 成功 |
| 保存配置/重载接口强制刷新 | 不生效 | ✅ `initialized: true` |

## 验证步骤

1. 管理后台 → SMTP 设置 → 填写真实 SMTP 授权码并保存
2. 发送测试邮件 → 成功
3. **刷新页面**
4. 再次发送测试邮件 → 成功（修复前此处报 535）
5. 修改授权码为错误值并保存 → 发送测试邮件 → 应失败并提示认证错误（确认强制刷新生效）
6. 恢复正确授权码保存 → 测试通过
