### PR TITLE
fix(db-sync): 修复重复 username 导致数据库迁移/同步失败

### DIFF
--- a/scripts/create-admin.js
+++ b/scripts/create-admin.js
@@ -29,6 +29,20 @@ async function main() {
       return existingSuperAdmin[0]
     }
 
+    // 没有超级管理员但 username=admin 已被其他角色占用时跳过创建，避免产生重复 username
+    const existingAdminName = await db
+      .select()
+      .from(users)
+      .where(eq(users.username, 'admin'))
+      .limit(1)
+
+    if (existingAdminName.length > 0) {
+      console.warn(
+        `⚠️ username=admin 已被用户#${existingAdminName[0].id}（role=${existingAdminName[0].role}）占用，跳过创建管理员`
+      )
+      return existingAdminName[0]
+    }
+
     // 创建管理员
     const hashedPassword = await bcrypt.hash('admin123', 10)
     const [admin] = await db

--- a/scripts/db-sync.js
+++ b/scripts/db-sync.js
@@ -201,6 +201,37 @@ async function indexExists(sql, tableName, indexName) {
   return result[0]?.exists === true
 }
 
+// 重复 username 会阻塞 User_username_unique 唯一索引的创建（push/migrate 均会失败）。
+// 同步前把多余行重命名为 username_<后缀>，保留最早一行，保证唯一索引可创建。
+async function ensureNoDuplicateUsernames(sql) {
+  if (!(await tableExists(sql, 'User'))) return
+
+  const duplicates = await sql`
+    SELECT username, array_agg(id ORDER BY id) AS ids
+    FROM "User"
+    WHERE username IS NOT NULL
+    GROUP BY username
+    HAVING COUNT(*) > 1
+  `
+
+  if (duplicates.length === 0) return
+
+  warn('检测到 User.username 重复值，重命名多余行以允许创建唯一索引')
+  for (const dup of duplicates) {
+    const [keptId, ...extraIds] = dup.ids
+    for (const id of extraIds) {
+      let suffix = 2
+      let newUsername = `${dup.username}_${suffix}`
+      while ((await sql`SELECT 1 FROM "User" WHERE username = ${newUsername} LIMIT 1`).length > 0) {
+        suffix += 1
+        newUsername = `${dup.username}_${suffix}`
+      }
+      await sql`UPDATE "User" SET username = ${newUsername} WHERE id = ${id}`
+      warn(`User#${id}: ${dup.username} -> ${newUsername}（保留最早记录 User#${keptId}）`)
+    }
+  }
+}
+
 // 检查数据库schema是否包含当前代码依赖的关键对象。
 async function checkSchemaConsistency(sql) {
   const requiredEnums = [
@@ -411,6 +442,8 @@ async function main() {
       }
       ok('空库迁移完成')
     } else {
+      // 重复 username 会阻塞唯一索引创建（push/migrate 均失败），先修复数据再同步
+      await ensureNoDuplicateUsernames(sql)
       const migrationRecordsExist = await hasMigrationRecords(sql)
       if (migrationRecordsExist) {
         // 正常数据库必须先应用待执行迁移，再检查最终结构；否则新增字段会被误判为schema损坏。


### PR DESCRIPTION
# 修复：数据库同步在重复 username 时失败，导致每次更新部署中止

## 问题描述

每次更新部署时，数据库同步流程必然失败并终止部署。部署日志（`voicehub-voicehub-1` 容器日志）关键片段：

```
⚠️  检测到 legacy 数据库迁移记录为空，检查schema并写入迁移基线。
⚠️  检测到数据库schema不完整，缺少: User.User_username_unique index
🔄 legacy schema不完整，尝试使用 push --force 进行同步...
PostgresError: could not create unique index "User_username_unique"
  detail: 'Key (username)=(admin) is duplicated.'
❌ push 后数据库schema仍不完整
❌ 部署失败: 数据库同步失败，已终止部署以避免运行时schema不一致
```

## 根因分析

1. **唯一索引的删除与恢复**：`User.username` 的唯一约束在 `20250828081010_careful_shinobi_shaw.sql` 中被移除（OAuth/身份体系改造期间），直到 `20260826033254_add_registration_review_grade_class_and_note_review.sql`（2026-08-26）才以 `User_username_unique` 唯一索引的形式恢复。在约束缺失的约一年窗口期内，数据库层面不强制 username 唯一。

2. **legacy 库路径**：生产库为早期用 `db:push` 建立的 legacy 库（`__drizzle_migrations__` 无记录）。`scripts/db-sync.js` 检测到 schema 不完整（缺该唯一索引）后走 `drizzle-kit push --force` 修复路径。

3. **重复数据阻塞索引创建**：窗口期内 `User` 表积累了重复的 `username='admin'` 行（至少两行）。`push` 尝试创建唯一索引时被 PostgreSQL 以 `23505 duplicate key` 拒绝，修复路径失败 → 部署中止。由于失败发生在迁移基线写入之前，每次部署都会重走同一条失败路径，因此**每次更新都失败**。

4. **重复数据的来源**：`scripts/deploy.js` 每次部署后都会执行 `create-admin.js`，而它只检查"是否已有 `SUPER_ADMIN` 角色"，**不检查 `username='admin'` 是否已被占用**。一旦存在非 SUPER_ADMIN 角色的 admin 用户（或角色被调整），就会再插入一条 `username='admin'` 的记录，在约束缺失期间不会报错，从而产生重复。

## 修复内容

| 文件 | 修改 |
|---|---|
| `scripts/db-sync.js` | 新增 `ensureNoDuplicateUsernames()`：在 migrate/push 之前检测 `User.username` 重复，将多余行重命名为 `username_2`/`username_3`…（保留最早一行），并打印重命名日志；之后唯一索引可以正常创建。所有外键均引用 `users.id` 而非 username，重命名不影响任何关联数据。 |
| `scripts/create-admin.js` | 创建管理员前增加 `username='admin'` 占用检查：已被占用（无论角色）则跳过创建并告警，从源头避免部署流程再次产生重复 admin。 |

## 验证步骤

1. 本地 PostgreSQL 复现：删除 `User_username_unique` 索引 → 插入两行重复 `admin` → 运行修复逻辑（检测 → 重命名 → 重建唯一索引）→ 索引创建成功、重复插入被 23505 拒绝。
2. 直接运行修改后的 `scripts/db-sync.js` 两轮：
   - 第一轮（legacy 库，无迁移记录）：自动写入 46 条迁移基线，同步成功；
   - 第二轮（有迁移记录）：`db:migrate` 同步成功——即修复后连续两次部署均可通过。
3. 生产部署验证：重复 `admin` 行会被自动重命名为 `admin_2`，`User_username_unique` 索引成功创建，后续更新不再中止。

## 涉及文件

- `scripts/db-sync.js`
- `scripts/create-admin.js`
