### PR TITLE
feat(music): 新增 ChKSz 音源支持，支持用户自配 API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,7 @@ VoiceHub/
 │   │   ├── useAuth.ts          # 认证功能hooks
 │   │   ├── useBackgroundRenderer.ts # 背景渲染hooks
 │   │   ├── useBilibiliPreview.ts # Bilibili视频预览hooks
+│   │   ├── useChkszSource.ts   # ChKSz音源hooks
 │   │   ├── useErrorHandler.ts  # 错误处理hooks
 │   │   ├── useImportantNotification.ts # 重要通知全局状态与已读处理
 │   │   ├── useLocaleText.ts   # i18n 文案访问与服务端错误码本地化hooks

--- a/app/components/Songs/RequestForm.vue
+++ b/app/components/Songs/RequestForm.vue
@@ -1816,7 +1816,7 @@ let audioMatchSilentNode = null
 // 音源管理器
 const musicSources = useMusicSources()
 const { currentSource, sourceStatus, sourceStatusSummary, currentSourceInfo } = musicSources
-const { checkNeteaseLoginStatus: updateGlobalNeteaseStatus } = useAudioQuality()
+const { checkNeteaseLoginStatus: updateGlobalNeteaseStatus, persistNeteaseVipFlag, clearNeteaseVipFlag } = useAudioQuality()
 const searchError = ref('')
 
 // 手动输入相关
@@ -2271,6 +2271,8 @@ const checkNeteaseLoginStatus = async () => {
           isNeteaseLoggedIn.value = true
           neteaseUser.value = dataObj.profile || dataObj.account
           localStorage.setItem('netease_user', JSON.stringify(neteaseUser.value))
+          // 同步 VIP 标志（vipType 非 0 即 VIP）
+          persistNeteaseVipFlag(dataObj.profile)
           // 同步全局网易云登录状态
           updateGlobalNeteaseStatus()
         } else {
@@ -2373,6 +2375,7 @@ const handleLoginSuccess = (data) => {
   if (import.meta.client) {
     localStorage.setItem('netease_cookie', data.cookie)
     localStorage.setItem('netease_user', JSON.stringify(data.user))
+    persistNeteaseVipFlag(data.user)
     updateGlobalNeteaseStatus()
   }
 }
@@ -2386,6 +2389,7 @@ const handleLogoutNetease = () => {
   if (import.meta.client) {
     localStorage.removeItem('netease_cookie')
     localStorage.removeItem('netease_user')
+    clearNeteaseVipFlag()
     updateGlobalNeteaseStatus()
   }
 }

--- a/app/components/Songs/ScheduleList.vue
+++ b/app/components/Songs/ScheduleList.vue
@@ -682,7 +682,7 @@ const props = defineProps({
 
 // 音频播放相关 - 使用全局音频播放器
 const audioPlayer = useAudioPlayer()
-const { checkNeteaseLoginStatus: updateGlobalNeteaseStatus } = useAudioQuality()
+const { checkNeteaseLoginStatus: updateGlobalNeteaseStatus, persistNeteaseVipFlag } = useAudioQuality()
 const { currentLocale, songs: songsLocale } = useLocale()
 const locale = computed(() => songsLocale.value?.scheduleList || {})
 const { t: callLocale } = useLocaleText(locale)
@@ -1178,6 +1178,8 @@ const handleLoginSuccess = (data) => {
   if (typeof window !== 'undefined') {
     localStorage.setItem('netease_cookie', data.cookie)
     localStorage.setItem('netease_user', JSON.stringify(data.user))
+    // 同步 VIP 标志（vipType 非 0 即 VIP）
+    persistNeteaseVipFlag(data.user)
     // 更新全局网易云登录状态，通知其他组件（如AudioPlayer）
     updateGlobalNeteaseStatus()
   }

--- a/app/composables/useAudioQuality.ts
+++ b/app/composables/useAudioQuality.ts
@@ -1,5 +1,6 @@
 import { computed, readonly, ref, watch } from 'vue'
 import { useLocale } from '~/utils/locale'
+import { getLoginStatus } from '~/utils/neteaseApi'
 
 // 音质配置
 export const QUALITY_OPTIONS = {
@@ -39,6 +40,59 @@ let globalAudioQuality: any = null
 // 网易云登录状态，全局共享
 const isNeteaseLoggedIn = ref(false)
 let isLoginStatusInitialized = false
+
+// 网易 VIP 标志（localStorage netease_vip）：vipType 非 0 即 VIP，仅 VIP 登录态才优先官方播放源
+const persistNeteaseVipFlag = (profile: any) => {
+  if (typeof window === 'undefined') return
+  try {
+    if (profile && typeof profile.vipType === 'number') {
+      localStorage.setItem('netease_vip', profile.vipType !== 0 ? '1' : '0')
+    } else {
+      localStorage.removeItem('netease_vip')
+    }
+  } catch (error) {
+    console.error('[audioQuality] Failed to persist netease_vip:', error)
+  }
+}
+
+const clearNeteaseVipFlag = () => {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.removeItem('netease_vip')
+  } catch {}
+}
+
+// 每会话一次的 VIP 状态静默刷新守卫
+let isNeteaseVipRefreshing = false
+let isNeteaseVipRefreshed = false
+
+// 静默刷新 VIP 状态：有 cookie 时调 /login/status 校验登录态并同步 VIP 标志
+const refreshNeteaseVipStatus = async () => {
+  if (typeof window === 'undefined' || isNeteaseVipRefreshed || isNeteaseVipRefreshing) return
+  let cookie: string | null = null
+  try {
+    cookie = localStorage.getItem('netease_cookie')
+  } catch {}
+  if (!cookie) return
+  isNeteaseVipRefreshing = true
+  try {
+    const res = await getLoginStatus(cookie)
+    const dataObj = res.body?.data || res.body
+    if (dataObj && dataObj.account) {
+      isNeteaseLoggedIn.value = true
+      persistNeteaseVipFlag(dataObj.profile)
+    } else {
+      // 登录失效：仅清 VIP 标志，cookie 与组件本地状态由组件级校验负责清理
+      clearNeteaseVipFlag()
+      isNeteaseLoggedIn.value = false
+    }
+  } catch {
+    // 网络异常保留本地状态
+  } finally {
+    isNeteaseVipRefreshing = false
+    isNeteaseVipRefreshed = true
+  }
+}
 
 export function useAudioQuality() {
   const { ui } = useLocale()
@@ -82,9 +136,13 @@ export function useAudioQuality() {
   // 初始化登录状态监听
   if (!isLoginStatusInitialized && typeof window !== 'undefined') {
     checkNeteaseLoginStatus()
+    refreshNeteaseVipStatus()
     window.addEventListener('storage', (e) => {
       if (e.key === 'netease_cookie') {
         checkNeteaseLoginStatus()
+        // 其他标签页登录态变化时重新同步 VIP 标志
+        isNeteaseVipRefreshed = false
+        refreshNeteaseVipStatus()
       }
     })
     isLoginStatusInitialized = true
@@ -173,6 +231,8 @@ export function useAudioQuality() {
     QUALITY_OPTIONS,
     DEFAULT_QUALITY,
     checkNeteaseLoginStatus,
-    isNeteaseLoggedIn: readonly(isNeteaseLoggedIn)
+    isNeteaseLoggedIn: readonly(isNeteaseLoggedIn),
+    persistNeteaseVipFlag,
+    clearNeteaseVipFlag
   }
 }

--- a/app/composables/useAudioQuality.ts
+++ b/app/composables/useAudioQuality.ts
@@ -59,7 +59,9 @@ const clearNeteaseVipFlag = () => {
   if (typeof window === 'undefined') return
   try {
     localStorage.removeItem('netease_vip')
-  } catch {}
+  } catch {
+    // localStorage 不可用时忽略
+  }
 }
 
 // 每会话一次的 VIP 状态静默刷新守卫
@@ -72,7 +74,9 @@ const refreshNeteaseVipStatus = async () => {
   let cookie: string | null = null
   try {
     cookie = localStorage.getItem('netease_cookie')
-  } catch {}
+  } catch {
+    // localStorage 不可用时跳过刷新
+  }
   if (!cookie) return
   isNeteaseVipRefreshing = true
   try {

--- a/app/composables/useChkszSource.ts
+++ b/app/composables/useChkszSource.ts
@@ -179,7 +179,7 @@ export function useChkszSource() {
    */
   const verifyChkszKey = async (
     key?: string
-  ): Promise<{ valid: boolean; message: string; detail?: string; quotaRemaining?: number }> => {
+  ): Promise<{ valid: boolean; message: string; detail?: string }> => {
     const apiKey = (key !== undefined ? key : chkszApiKey.value).trim()
     if (!apiKey) {
       return { valid: false, message: 'empty' }

--- a/app/composables/useChkszSource.ts
+++ b/app/composables/useChkszSource.ts
@@ -1,4 +1,4 @@
-import { watch } from 'vue'
+import { ref, watch } from 'vue'
 
 // ChKSz 音源（api.chksz.com）：用户自配 apikey，前端直连（接口返回 Access-Control-Allow-Origin: *）
 // 仅支持 netease / tencent 平台，接口免费配额有限（约 400 次 + 每分钟 20 次），需缓存与限流
@@ -44,15 +44,15 @@ const readStoredKey = (): string => {
   }
 }
 
-let globalChkszState: any = null
+let globalChkszKey: any = null
 
 export function useChkszSource() {
-  if (!globalChkszState) {
-    globalChkszState = useState<string>('chksz-api-key', () => readStoredKey())
+  if (!globalChkszKey) {
+    globalChkszKey = ref(readStoredKey())
 
     if (import.meta.client) {
       watch(
-        globalChkszState,
+        globalChkszKey,
         (newValue) => {
           try {
             if (newValue && newValue.trim()) {
@@ -69,7 +69,7 @@ export function useChkszSource() {
     }
   }
 
-  const chkszApiKey = globalChkszState
+  const chkszApiKey = globalChkszKey
 
   const hasChkszKey = () => {
     const key = chkszApiKey.value

--- a/app/composables/useChkszSource.ts
+++ b/app/composables/useChkszSource.ts
@@ -1,0 +1,213 @@
+import { watch } from 'vue'
+
+// ChKSz 音源（api.chksz.com）：用户自配 apikey，前端直连（接口返回 Access-Control-Allow-Origin: *）
+// 仅支持 netease / tencent 平台，接口免费配额有限（约 400 次 + 每分钟 20 次），需缓存与限流
+const CHKSZ_BASE_URL = 'https://api.chksz.com'
+const STORAGE_KEY = 'chksz_api_key'
+
+// 播放链接缓存（5 分钟，chksz 返回的直链有时效）
+const CHKSZ_CACHE_TTL = 5 * 60 * 1000
+// 滑动窗口限流：60 秒内最多 18 次，留余量规避接口 20 次/分钟限制
+const CHKSZ_RATE_LIMIT_MAX = 18
+const CHKSZ_RATE_LIMIT_WINDOW = 60 * 1000
+
+// 项目音质值 → chksz 接口参数
+// 网易 level：standard/exhigh/lossless/hires/jymaster
+const NETEASE_LEVEL_MAP: Record<number, string> = {
+  2: 'standard',
+  4: 'exhigh',
+  5: 'lossless',
+  6: 'hires',
+  9: 'jymaster'
+}
+// QQ size：128k/320k/flac/hires/master
+const TENCENT_SIZE_MAP: Record<number, string> = {
+  4: '128k',
+  8: '320k',
+  10: 'flac',
+  11: 'hires',
+  14: 'master'
+}
+
+const chkszUrlCache = new Map<string, { url: string; expireAt: number }>()
+// 同 key 请求合并，避免并发重复请求
+const chkszInflight = new Map<string, Promise<string | null>>()
+// 最近请求时间戳（滑动窗口限流）
+const chkszRequestTimes: number[] = []
+
+const readStoredKey = (): string => {
+  if (typeof window === 'undefined') return ''
+  try {
+    return localStorage.getItem(STORAGE_KEY) || ''
+  } catch {
+    return ''
+  }
+}
+
+let globalChkszState: any = null
+
+export function useChkszSource() {
+  if (!globalChkszState) {
+    globalChkszState = useState<string>('chksz-api-key', () => readStoredKey())
+
+    if (import.meta.client) {
+      watch(
+        globalChkszState,
+        (newValue) => {
+          try {
+            if (newValue && newValue.trim()) {
+              localStorage.setItem(STORAGE_KEY, newValue.trim())
+            } else {
+              localStorage.removeItem(STORAGE_KEY)
+            }
+          } catch (error) {
+            console.error('[chksz] Failed to save apikey:', error)
+          }
+        },
+        { deep: true }
+      )
+    }
+  }
+
+  const chkszApiKey = globalChkszState
+
+  const hasChkszKey = () => {
+    const key = chkszApiKey.value
+    return !!(key && key.trim())
+  }
+
+  const clearChkszKey = () => {
+    chkszApiKey.value = ''
+  }
+
+  const checkRateLimit = (): boolean => {
+    const now = Date.now()
+    const windowStart = now - CHKSZ_RATE_LIMIT_WINDOW
+    while (chkszRequestTimes.length > 0 && chkszRequestTimes[0] < windowStart) {
+      chkszRequestTimes.shift()
+    }
+    if (chkszRequestTimes.length >= CHKSZ_RATE_LIMIT_MAX) {
+      return false
+    }
+    chkszRequestTimes.push(now)
+    return true
+  }
+
+  /**
+   * 通过 ChKSz 获取播放链接
+   * @returns 播放 URL；未配 key / 不支持的平台音质 / 接口失败均返回 null（走降级链）
+   */
+  const getChkszMusicUrl = async (
+    platform: string,
+    musicId: string | number,
+    quality: number | string
+  ): Promise<string | null> => {
+    if (!hasChkszKey()) return null
+
+    const apiKey = chkszApiKey.value.trim()
+    const normalizedQuality = Number(quality)
+    let endpoint = ''
+    let qualityParam = ''
+
+    if (platform === 'netease') {
+      const level = NETEASE_LEVEL_MAP[normalizedQuality]
+      if (!level) return null
+      endpoint = '163_music'
+      qualityParam = `level=${level}`
+    } else if (platform === 'tencent') {
+      const size = TENCENT_SIZE_MAP[normalizedQuality]
+      if (!size) return null
+      endpoint = 'qq_music'
+      qualityParam = `size=${size}&type=json`
+    } else {
+      return null
+    }
+
+    const cacheKey = `${platform}:${musicId}:${qualityParam}`
+    const cached = chkszUrlCache.get(cacheKey)
+    if (cached && cached.expireAt > Date.now()) {
+      return cached.url
+    }
+
+    const now = Date.now()
+    for (const [key, entry] of chkszUrlCache) {
+      if (entry.expireAt <= now) {
+        chkszUrlCache.delete(key)
+      }
+    }
+
+    const inflight = chkszInflight.get(cacheKey)
+    if (inflight) {
+      return inflight
+    }
+
+    if (!checkRateLimit()) {
+      console.warn('[chksz] 请求过于频繁，跳过本次请求')
+      return null
+    }
+
+    const promise = (async (): Promise<string | null> => {
+      try {
+        const apiUrl =
+          `${CHKSZ_BASE_URL}/api/${endpoint}?` +
+          `${platform === 'netease' ? 'id' : 'mid'}=${encodeURIComponent(String(musicId))}&` +
+          `${qualityParam}&apikey=${encodeURIComponent(apiKey)}`
+        const response = await fetch(apiUrl, { signal: AbortSignal.timeout(8000) })
+        if (!response.ok) return null
+        const data: any = await response.json()
+        const url = platform === 'netease' ? data?.data?.url : data?.url
+        if (data?.code === 200 && url && /^https?:\/\//i.test(String(url))) {
+          const finalUrl = String(url)
+          chkszUrlCache.set(cacheKey, { url: finalUrl, expireAt: Date.now() + CHKSZ_CACHE_TTL })
+          return finalUrl
+        }
+      } catch (error) {
+        console.warn('[chksz] 获取播放链接失败:', error)
+      }
+      return null
+    })()
+
+    chkszInflight.set(cacheKey, promise)
+    promise.finally(() => {
+      chkszInflight.delete(cacheKey)
+    })
+    return promise
+  }
+
+  /**
+   * 验证 apikey 有效性（消耗 1 次接口配额）
+   */
+  const verifyChkszKey = async (
+    key?: string
+  ): Promise<{ valid: boolean; message: string; detail?: string; quotaRemaining?: number }> => {
+    const apiKey = (key !== undefined ? key : chkszApiKey.value).trim()
+    if (!apiKey) {
+      return { valid: false, message: 'empty' }
+    }
+    try {
+      const response = await fetch(
+        `${CHKSZ_BASE_URL}/api/163_music?id=347230&level=standard&apikey=${encodeURIComponent(apiKey)}`,
+        { signal: AbortSignal.timeout(8000) }
+      )
+      if (!response.ok) {
+        return { valid: false, message: `http_${response.status}` }
+      }
+      const data: any = await response.json()
+      if (data?.code === 200 && data?.data?.url) {
+        return { valid: true, message: 'ok' }
+      }
+      // key 无效（401/403 语义）或配额耗尽时接口返回业务错误码
+      return { valid: false, message: 'api_error', detail: data?.msg }
+    } catch (error: any) {
+      return { valid: false, message: error?.name === 'TimeoutError' ? 'timeout' : 'network' }
+    }
+  }
+
+  return {
+    chkszApiKey,
+    hasChkszKey,
+    clearChkszKey,
+    getChkszMusicUrl,
+    verifyChkszKey
+  }
+}

--- a/app/pages/account/index.vue
+++ b/app/pages/account/index.vue
@@ -615,11 +615,16 @@ const testChkszKey = async () => {
       network: locale.value.musicSource.testNetwork,
       api_error: locale.value.musicSource.testInvalid,
       http_401: locale.value.musicSource.testInvalid,
-      http_403: locale.value.musicSource.testInvalid
+      http_403: locale.value.musicSource.testInvalid,
+      http_429: locale.value.musicSource.testInvalid
+    }
+    let text = textMap[result.message] || locale.value.musicSource.testNetwork
+    if (!result.valid && result.detail) {
+      text += `（${result.detail}）`
     }
     chkszTestResult.value = {
       valid: result.valid,
-      text: textMap[result.message] || locale.value.musicSource.testNetwork
+      text
     }
   } finally {
     chkszTesting.value = false

--- a/app/pages/account/index.vue
+++ b/app/pages/account/index.vue
@@ -194,6 +194,94 @@
             </div>
           </section>
 
+          <!-- 音源设置（ChKSz） -->
+          <section :class="sectionClass">
+            <div class="flex items-center gap-3 border-b border-border-secondary-50 pb-5 mb-6">
+              <div class="p-2.5 bg-warning-10 rounded-xl flex items-center justify-center">
+                <ListMusic :size="20" class="text-warning" />
+              </div>
+              <div>
+                <h2 class="text-base font-black text-text-primary">{{ locale.musicSource.title }}</h2>
+                <p class="text-xs text-text-tertiary mt-0.5">{{ locale.musicSource.desc }}</p>
+              </div>
+            </div>
+
+            <div class="max-w-xl space-y-4">
+              <div class="space-y-2">
+                <label class="text-[10px] font-black text-text-disabled uppercase tracking-widest" for="chksz-apikey-input">
+                  {{ locale.musicSource.keyLabel }}
+                </label>
+                <div class="flex items-stretch gap-2">
+                  <div class="flex-1 min-w-0 flex items-center rounded-xl border border-border-secondary bg-bg-primary-45 focus-within:border-border-tertiary transition-colors">
+                    <input
+                      id="chksz-apikey-input"
+                      v-model="chkszKeyInput"
+                      :type="showChkszKey ? 'text' : 'password'"
+                      :placeholder="locale.musicSource.keyPlaceholder"
+                      autocomplete="off"
+                      class="flex-1 min-w-0 bg-transparent px-4 py-2.5 font-mono text-xs text-text-primary outline-none"
+                    >
+                    <button
+                      type="button"
+                      class="px-3 text-text-tertiary hover:text-text-primary transition-colors shrink-0"
+                      :title="showChkszKey ? locale.musicSource.hideKey : locale.musicSource.showKey"
+                      @click="showChkszKey = !showChkszKey"
+                    >
+                      <EyeOff v-if="showChkszKey" :size="15" />
+                      <Eye v-else :size="15" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div class="flex flex-wrap items-center gap-2">
+                <button
+                  class="inline-flex items-center justify-center gap-2 px-4 py-2 bg-primary hover:bg-primary-hover text-text-primary text-xs font-bold rounded-xl transition-all disabled:opacity-50"
+                  :disabled="chkszTesting || chkszKeyInput.trim() === chkszApiKey"
+                  @click="saveChkszKey"
+                >
+                  <Check :size="14" />
+                  {{ locale.musicSource.save }}
+                </button>
+                <button
+                  class="inline-flex items-center justify-center gap-2 px-4 py-2 border border-border-secondary bg-bg-primary-40 hover:bg-bg-tertiary text-text-secondary text-xs font-bold rounded-xl transition-all disabled:opacity-50"
+                  :disabled="chkszTesting || (!chkszApiKey && !chkszKeyInput)"
+                  @click="clearChkszKeySetting"
+                >
+                  <Trash2 :size="14" />
+                  {{ locale.musicSource.clear }}
+                </button>
+                <button
+                  class="inline-flex items-center justify-center gap-2 px-4 py-2 border border-border-secondary bg-bg-primary-40 hover:bg-bg-tertiary text-text-secondary text-xs font-bold rounded-xl transition-all disabled:opacity-50"
+                  :disabled="chkszTesting || (!chkszKeyInput.trim() && !chkszApiKey)"
+                  @click="testChkszKey"
+                >
+                  <RefreshCw v-if="chkszTesting" :size="14" class="animate-spin" />
+                  <Play v-else :size="14" />
+                  {{ locale.musicSource.test }}
+                </button>
+              </div>
+
+              <p
+                v-if="chkszTestResult"
+                class="text-xs font-bold leading-relaxed"
+                :class="chkszTestResult.valid ? 'text-success' : 'text-error'"
+              >
+                {{ chkszTestResult.text }}
+              </p>
+
+              <p class="text-xs text-text-tertiary leading-relaxed">
+                {{ locale.musicSource.hint }}
+                <a
+                  href="https://api.chksz.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary hover:text-primary-hover font-bold underline underline-offset-2"
+                >api.chksz.com</a>
+              </p>
+            </div>
+          </section>
+
           <!-- 修改密码 -->
           <section :class="sectionClass">
             <div class="flex items-center gap-3 border-b border-border-secondary-50 pb-5 mb-6">
@@ -426,11 +514,15 @@ import {
   ArrowLeft,
   Check,
   Copy,
+  Eye,
+  EyeOff,
   KeyRound,
   Link as LinkIcon,
+  ListMusic,
   Lock,
   LogOut,
   Monitor,
+  Play,
   Plus,
   RefreshCw,
   Trash2,
@@ -439,6 +531,7 @@ import {
 } from '@lucide/vue'
 import AccountSocialBindings from '~/components/Account/SocialBindings.vue'
 import { useAuth } from '~/composables/useAuth'
+import { useChkszSource } from '~/composables/useChkszSource'
 import { useToast } from '~/composables/useToast'
 import ConfirmDialog from '~/components/UI/ConfirmDialog.vue'
 import { useLocale } from '~/utils/locale'
@@ -488,6 +581,51 @@ const sessions = ref([])
 const sessionsLoading = ref(false)
 const sessionsRevoking = ref(false)
 
+// 音源设置（ChKSz apikey，仅存本浏览器 localStorage）
+const { chkszApiKey, clearChkszKey, verifyChkszKey } = useChkszSource()
+const chkszKeyInput = ref('')
+const showChkszKey = ref(false)
+const chkszTesting = ref(false)
+const chkszTestResult = ref(null)
+
+const saveChkszKey = () => {
+  const trimmed = chkszKeyInput.value.trim()
+  if (!trimmed) return
+  chkszApiKey.value = trimmed
+  showToast(locale.value.musicSource.saveSuccess, 'success')
+}
+
+const clearChkszKeySetting = () => {
+  clearChkszKey()
+  chkszKeyInput.value = ''
+  chkszTestResult.value = null
+  showToast(locale.value.musicSource.clearSuccess, 'success')
+}
+
+const testChkszKey = async () => {
+  chkszTesting.value = true
+  chkszTestResult.value = null
+  const keyToTest = chkszKeyInput.value.trim() || chkszApiKey.value
+  try {
+    const result = await verifyChkszKey(keyToTest)
+    const textMap = {
+      ok: locale.value.musicSource.testSuccess,
+      empty: locale.value.musicSource.testEmpty,
+      timeout: locale.value.musicSource.testTimeout,
+      network: locale.value.musicSource.testNetwork,
+      api_error: locale.value.musicSource.testInvalid,
+      http_401: locale.value.musicSource.testInvalid,
+      http_403: locale.value.musicSource.testInvalid
+    }
+    chkszTestResult.value = {
+      valid: result.valid,
+      text: textMap[result.message] || locale.value.musicSource.testNetwork
+    }
+  } finally {
+    chkszTesting.value = false
+  }
+}
+
 // 监听用户头像变化，重置错误状态
 watch(
   () => auth.user.value?.avatar,
@@ -501,6 +639,7 @@ onMounted(() => {
   refreshSiteConfig()
   loadPersonalApiKeys()
   loadSessions()
+  chkszKeyInput.value = chkszApiKey.value || ''
 
   if (route.query.message) {
     showToast(route.query.message, 'success')

--- a/app/utils/locale/en-US.ts
+++ b/app/utils/locale/en-US.ts
@@ -535,6 +535,25 @@ export const pages = {
       copyFailed: 'Copy failed. Select the key and copy it manually.',
       logsFailed: 'Failed to load call logs'
     },
+    musicSource: {
+      title: 'Music Source',
+      desc: 'Configure your personal source API key for higher-quality playback',
+      keyLabel: 'ChKSz API Key',
+      keyPlaceholder: 'Paste your ChKSz API key',
+      showKey: 'Show key',
+      hideKey: 'Hide key',
+      save: 'Save',
+      clear: 'Clear',
+      test: 'Test',
+      saveSuccess: 'Source API key saved (this browser only)',
+      clearSuccess: 'Source API key cleared',
+      testSuccess: 'Test passed: key is valid and the source is available',
+      testInvalid: 'Test failed: key is invalid or restricted',
+      testTimeout: 'Test timed out, please try again later',
+      testNetwork: 'Network error: cannot reach the source service',
+      testEmpty: 'Enter an API key first',
+      hint: 'The key is stored in this browser only and never uploaded to the server. Get one at:'
+    },
     roles: {
       ADMIN: 'Administrator',
       SUPER_ADMIN: 'Super Administrator',

--- a/app/utils/locale/zh-CN.ts
+++ b/app/utils/locale/zh-CN.ts
@@ -546,6 +546,25 @@ export const pages = {
       copyFailed: '复制失败，请手动选择 Key 复制',
       logsFailed: '加载调用记录失败'
     },
+    musicSource: {
+      title: '音源设置',
+      desc: '配置个人音源 API Key，解锁更高音质的播放链接',
+      keyLabel: 'ChKSz API Key',
+      keyPlaceholder: '粘贴你的 ChKSz API Key',
+      showKey: '显示 Key',
+      hideKey: '隐藏 Key',
+      save: '保存',
+      clear: '清除',
+      test: '测试',
+      saveSuccess: '音源 API Key 已保存（仅保存在当前浏览器）',
+      clearSuccess: '音源 API Key 已清除',
+      testSuccess: '测试通过：Key 有效，音源可用',
+      testInvalid: '测试失败：Key 无效或已被限制',
+      testTimeout: '测试超时，请稍后重试',
+      testNetwork: '网络异常，无法连接音源服务',
+      testEmpty: '请先填写 API Key',
+      hint: 'Key 仅保存在当前浏览器，不会上传到服务器；可前往获取：'
+    },
     roles: {
       ADMIN: '管理员',
       SUPER_ADMIN: '超级管理员',

--- a/app/utils/musicUrl.ts
+++ b/app/utils/musicUrl.ts
@@ -1,5 +1,6 @@
 import { useAudioQuality } from '~/composables/useAudioQuality'
 import { useMusicSources } from '~/composables/useMusicSources'
+import { useChkszSource } from '~/composables/useChkszSource'
 import { getVkeysIdParam } from '~/utils/musicSources'
 import { parseBilibiliId } from '~/utils/bilibiliSource'
 
@@ -233,9 +234,24 @@ export async function getMusicUrlResult(
   }
 
   const { getQuality } = useAudioQuality()
+  const { getChkszMusicUrl, hasChkszKey } = useChkszSource()
 
   // 优先使用 options 中的 quality，否则使用全局设置
   const quality = options?.quality !== undefined ? options.quality : getQuality(platform)
+
+  // ChKSz 音源（用户自配 apikey）：非 VIP 登录态下最优先，VIP 登录态下官方链路之后的次优先
+  const isExcluded = (source: string) => (options?.excludeSources || []).includes(source)
+  const tryChksz = async (chkszQuality: number | string): Promise<MusicUrlResolveResult | null> => {
+    if (!hasChkszKey() || isExcluded('chksz')) {
+      return null
+    }
+    const chkszUrl = await getChkszMusicUrl(platform, musicId, chkszQuality)
+    if (chkszUrl) {
+      rememberMusicUrlSource(chkszUrl, 'chksz')
+      return { url: chkszUrl, source: 'chksz' }
+    }
+    return null
+  }
 
   if (platform === 'tencent') {
     const normalizedQuality = Number(quality)
@@ -288,6 +304,12 @@ export async function getMusicUrlResult(
       } catch (error: any) {
         console.warn('[musicUrl] QQ 官方登录态解析失败，降级第三方音源:', error?.message || error)
       }
+    }
+
+    // ChKSz 音源：VIP 官方之后的次优先，非 VIP/未登录时为最优先
+    const chkszResult = await tryChksz(qualityCandidates[0])
+    if (chkszResult) {
+      return chkszResult
     }
 
     // K×H 音源提取的 QQ 直连接口支持浏览器跨域，优先于 vkeys 使用。
@@ -411,6 +433,12 @@ export async function getMusicUrlResult(
     isNeteasePlatform &&
     typeof window !== 'undefined' &&
     !!window.localStorage.getItem('netease_cookie')
+  // 仅 VIP 登录态才优先走网易官方链路，非 VIP/未登录时 ChKSz 最优先
+  const isNeteaseVip =
+    isNeteasePlatform &&
+    typeof window !== 'undefined' &&
+    window.localStorage.getItem('netease_vip') === '1'
+  const neteaseOfficialFirst = hasNeteaseLogin && isNeteaseVip
 
   let finalMusicId = musicId
   let bilibiliCid: string | undefined
@@ -427,6 +455,14 @@ export async function getMusicUrlResult(
     excludeSources: options?.excludeSources
   }
 
+  // 非 VIP 登录态/未登录：ChKSz 音源最优先
+  if (isNeteasePlatform && !neteaseOfficialFirst) {
+    const chkszResult = await tryChksz(quality)
+    if (chkszResult) {
+      return chkszResult
+    }
+  }
+
   // 先使用统一组件的音源选择逻辑
   const backupResult = await getSongUrl(finalMusicId, quality, platform, undefined, extendedOptions)
   if (backupResult.success && backupResult.url) {
@@ -434,6 +470,14 @@ export async function getMusicUrlResult(
     return {
       url: backupResult.url,
       source: backupResult.source || 'music-source'
+    }
+  }
+
+  // VIP 登录态官方链路失败：ChKSz 作为次优先
+  if (isNeteasePlatform && neteaseOfficialFirst) {
+    const chkszResult = await tryChksz(quality)
+    if (chkszResult) {
+      return chkszResult
     }
   }
 


### PR DESCRIPTION
- 添加 ChKSz 音源相关本地化文本（中英文）
- 在账号设置页面新增音源配置界面，支持输入、显示、保存、清除和测试 ChKSz API Key
- 实现 useChkszSource 组合式函数，实现 API Key 管理、获取播放链接和验证功能
- 在音乐链接解析逻辑中集成 ChKSz 音源，非 VIP 登录态优先使用，VIP 登录态作为备用音源
- 优化网易云 VIP 状态同步，新增本地保存和刷新机制，保证 VIP 播放源优先调用
- 更新相关组件和组合式函数，新增图标和 UI 控件支持 ChKSz 音源操作
- 更新 README 文档，添加对 useChkszSource 的说明和注释