### PR TITLE
fix(lyric): 修复 LRC 时间戳解析丢行与歌词管线两处缺陷

### DIFF
--- a/README.md
+++ b/README.md
@@ -1419,6 +1419,7 @@ VoiceHub/
 │       ├── cors-origin-policy.test.ts # CORS 来源协议匹配测试
 │       ├── important-notification-policy.test.ts # 重要通知策略测试
 │       ├── initial-password-policy.test.ts # 初始密码状态策略测试
+│       ├── lyric-lrc-parse.test.ts # LRC 混合精度毫秒时间戳解析测试
 │       ├── notification-history-policy.test.ts # 通知批次引用、筛选与分页策略测试
 │       ├── oauth-state-cookie.test.ts # OAuth state Cookie 安全测试
 │       ├── password-policy.test.ts # 密码策略测试

--- a/app/composables/useLyricManager.ts
+++ b/app/composables/useLyricManager.ts
@@ -143,7 +143,7 @@ export const useLyricManager = () => {
           if (lines && lines.length > 0) {
             const validLines = lines.filter((l) => l.words && l.words.length > 0)
             if (validLines.length > 0) {
-              parsedLyrics = lines
+              parsedLyrics = validLines
               format = 'word-by-word'
               console.log('[LyricManager] 使用 YRC 格式')
             }

--- a/app/composables/useMusicSources.ts
+++ b/app/composables/useMusicSources.ts
@@ -298,7 +298,12 @@ const buildLyricUpgradeQueries = (meta: LyricUpgradeMeta) => {
   return [...queries].filter(Boolean)
 }
 
-const getLyricCacheKey = (platform: string, id: number | string, meta?: LyricUpgradeMeta) => {
+const getLyricCacheKey = (
+  platform: string,
+  id: number | string,
+  meta?: LyricUpgradeMeta,
+  settingsFlag = ''
+) => {
   const title = normalizeLyricMatchText(meta?.title || '')
   const artist = normalizeLyricMatchText(meta?.artist || '')
   const album = normalizeLyricMatchText(meta?.album || '')
@@ -307,7 +312,7 @@ const getLyricCacheKey = (platform: string, id: number | string, meta?: LyricUpg
   // 优先级不同时抓取路径不同，结果可能不同；无显式 priority 的调用不区分
   const priority = meta?.priority || ''
   const durationBucket = meta?.duration ? Math.round(meta.duration / 5000) : 0
-  return `lyric-v2:${platform}:${id}:${title}:${artist}:${album}:${durationBucket}:${upgradeFlag}:${priority}`
+  return `lyric-v2:${platform}:${id}:${title}:${artist}:${album}:${durationBucket}:${upgradeFlag}:${priority}:${settingsFlag}`
 }
 
 const cloneLyricData = (data: LyricResultData): LyricResultData => ({
@@ -561,7 +566,14 @@ export const useMusicSources = () => {
     data?: LyricResultData
     error?: string
   }> => {
-    const cacheKey = getLyricCacheKey(platform, id, meta)
+    // 抓取路径受歌词开关影响，开关值参与缓存键，避免切换后 60s 内命中按旧配置计算的结果
+    const settings = useLyricSettings()
+    const settingsFlag = [
+      settings.enableQQMusicLyric.value ? 1 : 0,
+      settings.enableOnlineTTMLLyric.value ? 1 : 0,
+      settings.amllDbServer.value || ''
+    ].join(':')
+    const cacheKey = getLyricCacheKey(platform, id, meta, settingsFlag)
     const unsubscribeProgress = subscribeLyricProgress(cacheKey, meta?.onProgress)
     const progressive = typeof meta?.onProgress === 'function'
 
@@ -572,7 +584,6 @@ export const useMusicSources = () => {
 
     const promise = (async () => {
       try {
-        const settings = useLyricSettings()
         const enabledSources = getEnabledSources()
         const neteaseSource = enabledSources.find((source) => source.id.includes('netease-backup'))
         const vkeysSource = enabledSources.find((source) => source.id === 'vkeys')

--- a/app/utils/lyric/lyricParser.ts
+++ b/app/utils/lyric/lyricParser.ts
@@ -2,7 +2,7 @@ import { cloneDeep } from 'lodash-es'
 import type { LyricLine } from '@applemusic-like-lyrics/lyric'
 import { parseTTML as parseTTMLLib } from '@applemusic-like-lyrics/lyric'
 import { extractLyricContent } from './qrc-parser'
-import { parseLrc } from './parseLrc'
+import { parseLrc, parseTimeToMs } from './parseLrc'
 
 /**
  * LRC 格式类型
@@ -21,7 +21,7 @@ type LyricWord = { word: string; startTime: number; endTime: number; romanWord: 
 
 // 预编译正则表达式（时间戳分钟位 1-2 位，需与 parseLrc 保持一致）
 const META_TAG_REGEX = /^\[[a-z]+:/i
-const TIME_TAG_REGEX = /\[(\d{1,2}):(\d{2})\.(\d{1,})\]/g
+const FORMAT_DETECT_TIME_TAG_REGEX = /\[(\d{1,2}):(\d{2})\.(\d{1,})\]/g
 const ENHANCED_TIME_TAG_REGEX = /<(\d{1,2}):(\d{2})\.(\d{1,})>/
 // 移除全局带状态的正则，改为在函数内使用 matchAll 或重新构建
 const LINE_TIME_REGEX = /^\[(\d{1,2}):(\d{2})\.(\d{1,})\]/
@@ -34,19 +34,6 @@ const DEFAULT_WORD_DURATION = 1000
 const ALIGN_TOLERANCE_MS = 300
 /** 二次最近邻对齐的漂移容差：兜底时间轴整体漂移较大的来源 */
 const DRIFT_TOLERANCE_MS = 1500
-
-/**
- * 解析时间戳为毫秒
- * 使用字符串补齐处理，避免浮点数计算误差
- */
-const parseTimeToMs = (min: string, sec: string, ms: string): number => {
-  const minutes = parseInt(min, 10)
-  const seconds = parseInt(sec, 10)
-  // 补齐到 3 位 (例如 "5" -> "500", "05" -> "050", "1234" -> "123")
-  const msNormalized = ms.padEnd(3, '0').slice(0, 3)
-  const milliseconds = parseInt(msNormalized, 10)
-  return minutes * 60 * 1000 + seconds * 1000 + milliseconds
-}
 
 /**
  * 创建 LyricWord 对象
@@ -84,7 +71,7 @@ export const detectLrcFormat = (content: string): LrcFormat => {
       return LrcFormat.Enhanced
     }
     // 检查逐字LRC
-    const matches = line.match(TIME_TAG_REGEX)
+    const matches = line.match(FORMAT_DETECT_TIME_TAG_REGEX)
     if (matches && matches.length > 1) {
       return LrcFormat.WordByWord
     }

--- a/app/utils/lyric/lyricParser.ts
+++ b/app/utils/lyric/lyricParser.ts
@@ -19,12 +19,12 @@ export enum LrcFormat {
 /** LyricWord 类型 */
 type LyricWord = { word: string; startTime: number; endTime: number; romanWord: string }
 
-// 预编译正则表达式
+// 预编译正则表达式（时间戳分钟位 1-2 位，需与 parseLrc 保持一致）
 const META_TAG_REGEX = /^\[[a-z]+:/i
-const TIME_TAG_REGEX = /\[(\d{2}):(\d{2})\.(\d{1,})\]/g
-const ENHANCED_TIME_TAG_REGEX = /<(\d{2}):(\d{2})\.(\d{1,})>/
+const TIME_TAG_REGEX = /\[(\d{1,2}):(\d{2})\.(\d{1,})\]/g
+const ENHANCED_TIME_TAG_REGEX = /<(\d{1,2}):(\d{2})\.(\d{1,})>/
 // 移除全局带状态的正则，改为在函数内使用 matchAll 或重新构建
-const LINE_TIME_REGEX = /^\[(\d{2}):(\d{2})\.(\d{1,})\]/
+const LINE_TIME_REGEX = /^\[(\d{1,2}):(\d{2})\.(\d{1,})\]/
 
 // QRC 解析相关正则 - 提前编译
 const QRC_LINE_PATTERN = /^\[(\d+),(\d+)\](.*)$/
@@ -99,7 +99,7 @@ export const detectLrcFormat = (content: string): LrcFormat => {
 export const parseWordByWordLrc = (content: string): LyricLine[] => {
   const result: LyricLine[] = []
   let prevLine: LyricLine | null = null
-  const WORD_BY_WORD_PATTERN = /\[(\d{2}):(\d{2})\.(\d{1,})\]([^[\\]]*)/g
+  const WORD_BY_WORD_PATTERN = /\[(\d{1,2}):(\d{2})\.(\d{1,})\]([^[\\]]*)/g
 
   for (const rawLine of content.split(/\r?\n/)) {
     const line = rawLine.trim()
@@ -166,7 +166,7 @@ export const parseWordByWordLrc = (content: string): LyricLine[] => {
 export const parseEnhancedLrc = (content: string): LyricLine[] => {
   const result: LyricLine[] = []
   let prevLine: LyricLine | null = null
-  const ENHANCED_WORD_PATTERN = /<(\d{2}):(\d{2})\.(\d{1,})>([^<]*)/g
+  const ENHANCED_WORD_PATTERN = /<(\d{1,2}):(\d{2})\.(\d{1,})>([^<]*)/g
 
   for (const rawLine of content.split(/\r?\n/)) {
     const line = rawLine.trim()

--- a/app/utils/lyric/parseLrc.ts
+++ b/app/utils/lyric/parseLrc.ts
@@ -1,8 +1,21 @@
 import type { LyricLine } from '@applemusic-like-lyrics/lyric'
 
 // 时间戳支持 [m:ss] / [mm:ss] / [m:ss.f] / [mm:ss.fff]，分钟 1-2 位、毫秒位 1-3 位按十进制补齐 3 位
-const TIME_TAG_REGEX = /\[(\d{1,2}):(\d{2})(?:\.(\d{1,3}))?\]/g
+const LRC_LINE_TIME_TAG_REGEX = /\[(\d{1,2}):(\d{2})(?:\.(\d{1,3}))?\]/g
 const META_TAG_REGEX = /^\[[a-z]+:/i
+
+/** 毫秒位固定宽度（十进制小数补齐到毫秒） */
+const MS_DIGITS = 3
+/** 最后一行无后续行时的兜底展示时长 */
+const LAST_LINE_DURATION_MS = 5000
+
+/**
+ * 解析时间标签为毫秒，毫秒位按十进制小数补齐（.7 -> 700ms）
+ */
+export const parseTimeToMs = (min: string, sec: string, ms?: string): number => {
+  const msNormalized = (ms ?? '0').padEnd(MS_DIGITS, '0').slice(0, MS_DIGITS)
+  return parseInt(min, 10) * 60 * 1000 + parseInt(sec, 10) * 1000 + parseInt(msNormalized, 10)
+}
 
 export const parseLrc = (lrcContent: string): LyricLine[] => {
   if (!lrcContent) return []
@@ -17,22 +30,18 @@ export const parseLrc = (lrcContent: string): LyricLine[] => {
     // 跳过元数据
     if (META_TAG_REGEX.test(trimmedLine)) continue
 
-    const matches = [...trimmedLine.matchAll(TIME_TAG_REGEX)]
+    const matches = [...trimmedLine.matchAll(LRC_LINE_TIME_TAG_REGEX)]
+    // 不含合法时间戳的行视为非歌词行（元数据、杂项），静默跳过
     if (matches.length === 0) continue
 
     // 提取歌词文本（移除所有时间标签）
-    const text = trimmedLine.replace(TIME_TAG_REGEX, '').trim()
-    // 允许空行（作为间奏），但通常我们忽略完全空的行，除非为了显示间隔
+    const text = trimmedLine.replace(LRC_LINE_TIME_TAG_REGEX, '').trim()
+    // 纯时间戳行（间奏标记）不产出歌词行
     if (!text) continue
 
     // 处理一行多个时间标签的情况（重复歌词）
     for (const match of matches) {
-      const min = parseInt(match[1], 10)
-      const sec = parseInt(match[2], 10)
-      // 补齐毫秒
-      const msStr = (match[3] ?? '0').padEnd(3, '0').slice(0, 3)
-      const ms = parseInt(msStr, 10)
-      const startTime = min * 60 * 1000 + sec * 1000 + ms
+      const startTime = parseTimeToMs(match[1], match[2], match[3])
 
       result.push({
         startTime,
@@ -57,7 +66,7 @@ export const parseLrc = (lrcContent: string): LyricLine[] => {
     if (nextLine) {
       line.endTime = nextLine.startTime
     } else {
-      line.endTime = line.startTime + 5000 // 最后一行默认 5秒
+      line.endTime = line.startTime + LAST_LINE_DURATION_MS
     }
 
     // 更新单词结束时间

--- a/app/utils/lyric/parseLrc.ts
+++ b/app/utils/lyric/parseLrc.ts
@@ -1,7 +1,7 @@
 import type { LyricLine } from '@applemusic-like-lyrics/lyric'
 
-// 时间戳支持 [mm:ss] / [mm:ss.f] / [mm:ss.ff] / [mm:ss.fff]，毫秒位按十进制小数补齐 3 位
-const TIME_TAG_REGEX = /\[(\d{2}):(\d{2})(?:\.(\d{1,3}))?\]/g
+// 时间戳支持 [m:ss] / [mm:ss] / [m:ss.f] / [mm:ss.fff]，分钟 1-2 位、毫秒位 1-3 位按十进制补齐 3 位
+const TIME_TAG_REGEX = /\[(\d{1,2}):(\d{2})(?:\.(\d{1,3}))?\]/g
 const META_TAG_REGEX = /^\[[a-z]+:/i
 
 export const parseLrc = (lrcContent: string): LyricLine[] => {

--- a/app/utils/lyric/parseLrc.ts
+++ b/app/utils/lyric/parseLrc.ts
@@ -1,6 +1,7 @@
 import type { LyricLine } from '@applemusic-like-lyrics/lyric'
 
-const TIME_TAG_REGEX = /\[(\d{2}):(\d{2})\.(\d{2,3})\]/g
+// 时间戳支持 [mm:ss] / [mm:ss.f] / [mm:ss.ff] / [mm:ss.fff]，毫秒位按十进制小数补齐 3 位
+const TIME_TAG_REGEX = /\[(\d{2}):(\d{2})(?:\.(\d{1,3}))?\]/g
 const META_TAG_REGEX = /^\[[a-z]+:/i
 
 export const parseLrc = (lrcContent: string): LyricLine[] => {
@@ -29,7 +30,7 @@ export const parseLrc = (lrcContent: string): LyricLine[] => {
       const min = parseInt(match[1], 10)
       const sec = parseInt(match[2], 10)
       // 补齐毫秒
-      const msStr = match[3].padEnd(3, '0').slice(0, 3)
+      const msStr = (match[3] ?? '0').padEnd(3, '0').slice(0, 3)
       const ms = parseInt(msStr, 10)
       const startTime = min * 60 * 1000 + sec * 1000 + ms
 

--- a/tests/server/lyric-lrc-parse.test.ts
+++ b/tests/server/lyric-lrc-parse.test.ts
@@ -1,0 +1,117 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { parseLrc } from '../../app/utils/lyric/parseLrc.ts'
+
+// 复刻网易云 1427767861 歌词的时间戳结构（歌词正文用占位符替代，避免歌词入库）：
+// 元数据样行带时间戳，毫秒位混合 1/2/3 位小数，另含两行纯时间戳间奏行。
+// 旧正则要求毫秒位 2-3 位小数，会把 1 位小数的正文行整行丢弃。
+const NETEASE_MIXED_PRECISION_LRC = [
+  '[00:00.00] 作词 : 占位',
+  '[00:01.00] 作曲 : 占位',
+  '[00:34.55]样行01',
+  '[00:35.55]样行02',
+  '[00:36.55]样行03',
+  '[00:46.25]正文01',
+  '[00:53.50]正文02',
+  '[01:00.7]正文03',
+  '[01:08.49]正文04',
+  '[01:15.47]正文05',
+  '[01:19.13]正文06',
+  '[01:22.86]正文07',
+  '[01:26.36]正文08',
+  '[01:30.24]正文09',
+  '[01:33.89]正文10',
+  '[01:37.40]正文11',
+  '[01:41.00]正文12',
+  '[01:45.9]',
+  '[01:46.68]正文13',
+  '[01:54.0]正文14',
+  '[02:01.2]正文15',
+  '[02:08.59]正文16',
+  '[02:16.0]正文17',
+  '[02:19.63]正文18',
+  '[02:23.36]正文19',
+  '[02:27.0]正文20',
+  '[02:30.80]正文21',
+  '[02:34.29]正文22',
+  '[02:38.0]正文23',
+  '[02:41.61]正文24',
+  '[02:45.52]',
+  '[03:20.00]正文25',
+  '[03:27.6]正文26',
+  '[03:35.29]正文27',
+  '[03:38.82]正文28',
+  '[03:42.61]正文29',
+  '[03:46.14]正文30',
+  '[03:49.87]正文31',
+  '[03:53.46]正文32',
+  '[03:57.23]正文33',
+  '[04:00.84]正文34',
+  '[04:04.49]正文35',
+  '[04:08.1]正文36',
+  '[04:11.74]正文37',
+  '[04:15.24]正文38',
+  '[04:19.19]正文39',
+  '[04:22.86]正文40',
+  '[04:26.46]正文41',
+  '[04:29.93]正文42',
+  '[04:33.81]正文43'
+].join('\n')
+
+test('混合毫秒精度的 lrc 正文行全部保留', () => {
+  const lines = parseLrc(NETEASE_MIXED_PRECISION_LRC)
+  // 50 行 = 48 行带正文（含 5 行元数据样行）+ 2 行纯时间戳间奏行（按设计跳过）
+  assert.equal(lines.length, 48)
+})
+
+test('1 位毫秒小数按十进制补齐 3 位', () => {
+  const lines = parseLrc(NETEASE_MIXED_PRECISION_LRC)
+  // [01:00.7] -> 700ms；[02:16.0] -> 0ms
+  const line60 = lines.find((l) => l.startTime === 60700)
+  const line136 = lines.find((l) => l.startTime === 136000)
+  assert.ok(line60, '[01:00.7] 正文行未被解析')
+  assert.equal(line60.words[0].word, '正文03')
+  assert.ok(line136, '[02:16.0] 正文行未被解析')
+  assert.equal(line136.words[0].word, '正文17')
+})
+
+test('2/3 位毫秒小数解析不受影响', () => {
+  const lines = parseLrc(NETEASE_MIXED_PRECISION_LRC)
+  assert.ok(lines.find((l) => l.startTime === 46250), '[00:46.25] 解析错误')
+  assert.ok(lines.find((l) => l.startTime === 200000), '[03:20.00] 解析错误')
+})
+
+test('3 位毫秒小数原样解析', () => {
+  const lines = parseLrc('[00:46.123]三位小数行')
+  assert.equal(lines.length, 1)
+  assert.equal(lines[0].startTime, 46123)
+  assert.equal(lines[0].words[0].word, '三位小数行')
+})
+
+test('无小数毫秒的时间戳可解析', () => {
+  const lines = parseLrc('[00:46]无小数行\n[01:02]下一行')
+  assert.equal(lines.length, 2)
+  assert.equal(lines[0].startTime, 46000)
+  assert.equal(lines[0].words[0].word, '无小数行')
+  assert.equal(lines[1].startTime, 62000)
+})
+
+test('纯时间戳间奏行仍然跳过', () => {
+  const lines = parseLrc(NETEASE_MIXED_PRECISION_LRC)
+  // [01:45.9] 与 [02:45.52] 为空正文间奏行
+  assert.ok(!lines.find((l) => l.startTime === 105900))
+  assert.ok(!lines.find((l) => l.startTime === 165520))
+})
+
+test('输出按时间升序且时间标签从正文剔除', () => {
+  const lines = parseLrc(NETEASE_MIXED_PRECISION_LRC)
+  for (let i = 1; i < lines.length; i++) {
+    assert.ok(lines[i].startTime >= lines[i - 1].startTime)
+  }
+  const first = lines[0]
+  assert.equal(first.words[0].word, '作词 : 占位')
+})
+
+test('空内容返回空数组', () => {
+  assert.deepEqual(parseLrc(''), [])
+})

--- a/tests/server/lyric-lrc-parse.test.ts
+++ b/tests/server/lyric-lrc-parse.test.ts
@@ -112,6 +112,16 @@ test('输出按时间升序且时间标签从正文剔除', () => {
   assert.equal(first.words[0].word, '作词 : 占位')
 })
 
+test('1 位分钟写法可解析', () => {
+  const lines = parseLrc('[1:00.7]一位分钟\n[1:02]无小数\n[12:34.5]两位分钟')
+  assert.equal(lines.length, 3)
+  assert.equal(lines[0].startTime, 60700)
+  assert.equal(lines[0].words[0].word, '一位分钟')
+  assert.equal(lines[1].startTime, 62000)
+  assert.equal(lines[2].startTime, 754500)
+  assert.equal(lines[2].words[0].word, '两位分钟')
+})
+
 test('空内容返回空数组', () => {
   assert.deepEqual(parseLrc(''), [])
 })


### PR DESCRIPTION
# 歌词:修复 LRC 时间戳解析丢行与歌词管线两处缺陷

## 概述

网易云源播放部分歌曲时,歌词从某个时间点起**间断性缺失、缺失位置固定**(如「阿弥陀佛头摇摇 - 希望索任合资/洛天依Official」从 1:00 开始缺词),而网易官方客户端显示完整。根因是 `parseLrc` 的时间戳正则比 LRC 规范严格:毫秒位只接受 2-3 位小数,1 位小数时间戳(如 `[01:00.7]`)的正文行被整行静默丢弃。

本 PR 包含三部分:

1. **根因修复 + 兼容加固**:`LRC` 时间戳解析放宽为毫秒位 1-3 位小数、兼容无小数写法、分钟位 1-2 位;格式检测与逐字/增强解析的 5 处正则同步放宽,保持检测与解析一致;
2. **顺带修复歌词管线两处缺陷**:YRC 空词行进入播放器、歌词缓存键缺失开关维度;
3. **解析层可读性重构**(无行为变化):统一时间戳换算、消除两处同名正则歧义、魔法数字常量化、修正误导注释。

## 问题现象与根因

- **现象**:网易云 ID `1427767861` 的歌词从 1:00 起间断缺词,缺失行每次相同;网易客户端同一首歌歌词完整。
- **根因**:`app/utils/lyric/parseLrc.ts` 原时间戳正则 `\[(\d{2}):(\d{2})\.(\d{2,3})\]` 要求毫秒位 2-3 位小数;LRC 规范允许 1-3 位,该歌曲存储的歌词(version 5)恰好混有 `[01:00.7]`、`[01:54.0]`、`[02:16.0]` 等 1 位小数时间戳。这些行匹配失败后走 `matches.length === 0 → continue` 被**整行静默丢弃**:全曲 50 行 lrc 丢 8 行正文,第一行正是 `[01:00.7]`,与现象完全吻合。
- **为何客户端正常**:网易客户端解析器按规范兼容 1-3 位小数;本仓库同目录 `lyricParser.ts` 的格式检测正则本就是 `\d{1,}`,而实际解析的 `parseLrc` 更严——"检测得到、解析不了"使此 bug 长期隐蔽。

## 变更明细

### 1. LRC 时间戳解析兼容(根因修复 + 加固)

| 项 | 修复前 | 修复后 |
|---|---|---|
| 毫秒位小数 | 仅 2-3 位(`\d{2,3}`) | 1-3 位(`\d{1,3}`),按十进制补齐(`.7` → 700ms) |
| 无小数写法 `[mm:ss]` | 整行丢弃 | 兼容(`match[3] ?? '0'`) |
| 分钟位 | 仅 2 位 | 1-2 位(兼容 `[1:00.7]`) |

`lyricParser.ts` 的 `TIME_TAG_REGEX`、`ENHANCED_TIME_TAG_REGEX`、`LINE_TIME_REGEX`、`WORD_BY_WORD_PATTERN`、`ENHANCED_WORD_PATTERN` 5 处正则分钟位同步放宽,避免修复后出现新的"检测得到、解析不了"。

### 2. 顺带修复歌词管线两处缺陷

- **YRC 空词行进入播放器**(`useLyricManager.ts`):原代码以过滤后的 `validLines` 判定 YRC 解析结果可用,实际赋值的却是未过滤的原数组,`words` 为空的行会进入 AMLL 播放器(渲染行为未定义);现改为赋过滤结果,与 `useLyrics.convertLibraryLines` 的过滤语义对齐。
- **歌词缓存键缺失开关维度**(`useMusicSources.ts`):`getLyricCacheKey` 原含 `priority` 但不含 `enableQQMusicLyric`/`enableOnlineTTMLLyric`/`amllDbServer`,60s 缓存窗口内切换这些开关会命中按旧配置计算的抓取结果,表现为"开关不生效";现把开关值拼入缓存键。

### 3. 解析层可读性重构(无行为变化)

- `parseTimeToMs` 收敛为 `parseLrc.ts` 单份导出实现,`lyricParser.ts` 删除重复实现改为导入,消除双份毫秒换算逻辑漂移(原 bug 的温床);
- 两处同名 `TIME_TAG_REGEX` 重命名区分:行级解析 `LRC_LINE_TIME_TAG_REGEX`、格式检测 `FORMAT_DETECT_TIME_TAG_REGEX`;
- 末行兜底时长(5000ms)、毫秒位宽度(3)提为具名常量;
- 修正间奏行注释与代码矛盾之处;为"不含合法时间戳的行静默跳过"写明契约。

## 提交记录

| commit | 内容 |
|---|---|
| `cc3a7d9` | fix: LRC 解析兼容 1 位毫秒小数时间戳 |
| `5279184` | fix: 时间戳分钟位兼容 1-2 位 |
| `e5e1918` | refactor: 统一时间戳换算并消除同名正则歧义 |
| `8240bf1` | fix: YRC 空词行进入播放器 + 缓存键开关维度 |

## 变更清单

| 文件 | 变更 |
|---|---|
| `app/utils/lyric/parseLrc.ts` | 时间戳正则放宽;`parseTimeToMs` 单份实现并导出;常量化;注释修正 |
| `app/utils/lyric/lyricParser.ts` | 5 处正则分钟位同步放宽;复用 `parseTimeToMs`;检测正则改名 |
| `app/composables/useLyricManager.ts` | YRC 解析赋值改用过滤后的 validLines |
| `app/composables/useMusicSources.ts` | 歌词缓存键追加开关与 AMLL DB 地址维度 |
| `tests/server/lyric-lrc-parse.test.ts` | 新增回归测试(9 项) |
| `README.md` | 项目结构同步新增测试文件 |

## 兼容性说明

- 无数据库 schema 变更、无迁移、无 SystemSettings 字段变更、无 i18n 文案变更;
- 解析层纯前端修复,不改变任何接口行为与歌词获取路径;逐字歌词(YRC/QRC/增强型 LRC)解析路径不受影响(其正则本就兼容 1 位小数);
- 缓存键追加维度后,内存缓存(60s TTL)旧条目自然失效,无持久化影响。

## 验证步骤

1. `node --experimental-strip-types --test "tests/server/*.test.ts"`:134 项全过(含新增 9 项);
2. 真实数据端到端:网易云 `1427767861` 的 lrc 修复后 `parseLrc` 输出 48 行(修复前 40 行),逐行比对 0 缺失;
3. `eslint`(变更的 5 个源文件):0 error、0 新增 warning;
4. `check_i18n.py` 双语结构一致(0 差异);
5. 手工路径:`pnpm run dev` 播放该歌曲,1:00 起"佛门重地外"等此前缺失的行正常显示;播放中切换"QQ 歌词/在线 TTML"开关后重新拉取,结果按新配置生成。

## 已知边界与未包含项

- 秒位仍要求 2 位(`[0:46]` 整行跳过)、3 位分钟与 `[hh:mm:ss]` 不支持:真实数据未观测到这些形态,保持现状,契约已在测试与注释中记录;
- 多时间戳重复行(`[ts1][ts2]text`)被误判为逐字格式导致重复出现丢失:已定位的独立问题,拟单独 PR 处理;
- `useLyrics` 与 `useLyricManager` 双轨解析链路的收敛属更大范围重构,另行讨论。
